### PR TITLE
Divide the runtime into three separately typed stacks.

### DIFF
--- a/src/runtime/exec.rs
+++ b/src/runtime/exec.rs
@@ -1,10 +1,9 @@
-use super::{stack::Frame, values::Value, Runtime};
+use super::{stack::ActivationFrame, values::Value, Runtime};
 use crate::{
-    err,
     error::{Error, Result, ResultFrom},
     instructions::*,
 };
-use std::{convert::TryFrom, convert::TryInto, rc::Rc};
+use std::{convert::TryFrom, convert::TryInto};
 
 struct InvocationContext<'l> {
     runtime: &'l mut Runtime,
@@ -44,7 +43,7 @@ impl<'l> ActivationContext for InvocationContext<'l> {
     }
 
     fn push_value(&mut self, val: Value) -> Result<()> {
-        self.runtime.stack.push(val.into());
+        self.runtime.stack.push_value(val);
         Ok(())
     }
 
@@ -62,11 +61,8 @@ impl<'l> ActivationContext for InvocationContext<'l> {
 }
 
 impl<'l> InvocationContext<'l> {
-    fn current_frame(&self) -> Result<Rc<Frame>> {
-        match &self.runtime.current_frame {
-            Some(frame) => Ok(frame.clone()),
-            _ => err!("no current frame"),
-        }
+    fn current_frame(&self) -> Result<&ActivationFrame> {
+        self.runtime.stack.peek_activation()
     }
 
     #[allow(non_upper_case_globals)]

--- a/src/runtime/instance/data_instance.rs
+++ b/src/runtime/instance/data_instance.rs
@@ -1,6 +1,7 @@
 /// An data instance is the runtime representation of a data segment. [Spec][Spec]
 ///
 /// It holds a vector of bytes.
+///
 /// [Spec]: https://webassembly.github.io/spec/core/exec/runtime.html#data-instances
 #[allow(dead_code)]
 pub struct DataInstance {

--- a/src/runtime/instance/global_instance.rs
+++ b/src/runtime/instance/global_instance.rs
@@ -11,6 +11,8 @@ use crate::types::ValueType;
 ///
 /// It is an invariant of the semantics that the value has a type equal to the
 /// value type of globaltype.
+///
+/// [Spec]: https://webassembly.github.io/spec/core/exec/runtime.html#global-instances
 #[allow(dead_code)]
 pub struct GlobalInstance {
     pub typ: ValueType,

--- a/src/runtime/store.rs
+++ b/src/runtime/store.rs
@@ -14,6 +14,7 @@ use std::rc::Rc;
 /// abstract addresses. These are simply indices into the respective store
 /// component. In addition, an embedder may supply an uninterpreted set of host
 /// addresses.
+///
 /// [Spec]: https://webassembly.github.io/spec/core/exec/runtime.html#addresses
 pub mod addr {
     pub type FuncAddr = u32;
@@ -35,16 +36,14 @@ pub mod addr {
 /// It is an invariant of the semantics that no element or data instance is
 /// addressed from anywhere else but the owning module instances.
 /// Syntactically, the store is defined as a record listing the existing
-/// instances of each category:
+/// instances of each category
 ///
-///   store := {
-///     funcs [FunctionInstance]*,
-///     tables [TableInstance]*,
-///     mems [MemoryInstance]*,
-///     globals [GlobalInstance]*,
-///     elems [ElemInstance]*,
-///     data [DataInstance]*,
-///   }
+/// * [FunctionInstance](FunctionInstance)
+/// * [TableInstance](super::instance::TableInstance)
+/// * [MemInstance](super::instance::MemInstance)
+/// * [GlobalInstance](super::instance::GlobalInstance)
+/// * [ElemInstance](super::instance::ElemInstance)
+/// * [DataInstance](super::instance::DataInstance)
 ///
 /// [Spec]: https://webassembly.github.io/spec/core/exec/runtime.html#store
 #[derive(Default, Debug)]


### PR DESCRIPTION
The spec describes them as a single unified stack for convenience in the
doc writing, but representing them as three individually type stacks
leads to a much cleaner implementation.