### PR TITLE
Handled reserved tokens when lexing

### DIFF
--- a/src/format/text/token/mod.rs
+++ b/src/format/text/token/mod.rs
@@ -30,6 +30,7 @@ pub enum Token {
     LineComment,
     BlockComment,
     Keyword(String),
+    Reserved(String),
     Unsigned(u64),
     Signed(i64),
     Float(f64),


### PR DESCRIPTION
When lexing a number, if it ends up containing an idchar, switch to
treating it as a reserved token.