### PR TITLE
Lots of lexer cleanup, and stop trying to parse decimal floats manually

### DIFF
--- a/src/format/text/lex/chars.rs
+++ b/src/format/text/lex/chars.rs
@@ -1,0 +1,24 @@
+pub trait CharChecks { 
+    fn is_whitespace(&self) -> bool;
+    fn is_keyword_start(&self) -> bool;
+    fn is_idchar(&self) -> bool;
+}
+
+impl CharChecks for u8 {
+    fn is_idchar(&self) -> bool {
+        matches!(self,
+            b'0'..=b'9' | b'A'..=b'Z'  | b'a'..=b'z' | b'!' | b'#' |
+            b'$' | b'%' | b'&' | b'\'' | b'*' | b'+' | b'-' | b'/' |
+            b':' | b'<' | b'=' | b'>'  | b'?' | b'@' | b'\\' |
+            b'^' | b'_' | b'`' | b'|'  | b'~' | b'.'
+        )
+    }
+
+    fn is_keyword_start(&self) -> bool {
+        matches!(self, b'a'..=b'z')
+    }
+
+    fn is_whitespace(&self) -> bool {
+        matches!(self, b' ' | b'\t' | b'\n' | b'\r')
+    }
+}

--- a/src/format/text/lex/num.rs
+++ b/src/format/text/lex/num.rs
@@ -1,0 +1,80 @@
+use super::Token;
+use crate::format::text::token::Sign;
+
+/// Interpret a discriminated nan, "nan:0xABCDE".
+fn maybe_nan_or_inf(numchars: &str, sign: Sign) -> Option<Token> {
+    match numchars {
+        nc if nc == "nan" => Some(Token::NaN(sign)),
+        nc if nc == "inf" => Some(Token::Inf(sign)),
+        nc if nc.starts_with("nan:0x") => {
+            let (_, numpart) = &numchars.split_at(6);
+            match u32::from_str_radix(numpart, 16) {
+                Ok(nanx) => Some(Token::NaNx(sign, nanx as u32)),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Attempt to interpret the `idchars` as a number. If the conversion is successful, a [Token] is
+/// returned, otherwise, [None] is returned.
+pub fn maybe_number(idchars: &str) -> Option<Token> {
+    let snumchars = idchars.replace("_", "");
+    let mut numchars = snumchars.as_str();
+
+    if numchars.is_empty() {
+        return None;
+    }
+
+    let sign: Sign = numchars.chars().next().unwrap().into();
+    if sign != Sign::Unspecified {
+        let (_, rest) = numchars.split_at(1);
+        numchars = rest;
+    }
+
+    if let Some(t) = maybe_nan_or_inf(numchars, sign) {
+        return Some(t);
+    }
+
+    let radix = match numchars {
+        bs if bs.starts_with("0x") => {
+            let (_, rest) = numchars.split_at(2);
+            numchars = rest;
+            16
+        }
+        _ => 10,
+    };
+
+    // Now try integer
+    if let Ok(val) = u64::from_str_radix(numchars, radix) {
+        return Some(match sign {
+            Sign::Unspecified => Token::Unsigned(val),
+            Sign::Positive => Token::Signed(val as i64),
+            Sign::Negative => {
+                let iv = val as i64;
+                if iv < 0 {
+                    Token::Signed(iv)
+                } else {
+                    Token::Signed(-iv)
+                }
+            }
+        });
+    }
+
+    // Float w/o leading zero not accepted.
+    if numchars.as_bytes()[0] == b'.' {
+        return None;
+    }
+
+    // Now try decimal float:
+    if let Ok(val) = numchars.parse::<f64>() {
+        return match sign {
+            Sign::Positive | Sign::Unspecified => Some(Token::Float(val)),
+            Sign::Negative => Some(Token::Float(-val)),
+        };
+    }
+
+    // TODO hex float
+    None
+}

--- a/src/format/text/lex/num_test.rs
+++ b/src/format/text/lex/num_test.rs
@@ -1,0 +1,101 @@
+#[cfg(test)] 
+mod test {
+    use crate::format::text::token::{Sign, Token};
+    use crate::format::text::lex::num::maybe_number;
+
+
+    macro_rules! check {
+        ( $s:expr, $t:expr ) => {
+            {
+                println!("Checking {}", $s);
+                let result = maybe_number(&$s.to_string()).unwrap();
+                assert_eq!(result, $t);
+            }
+        };
+        ( $s:expr ) => {
+            {
+                println!("Checking {}", $s);
+                let result = maybe_number(&$s.to_string());
+                assert!(result == None);
+            }
+        }
+    }
+
+    #[test]
+    fn unsigned() {
+        check!("12345", Token::Unsigned(12345));
+        check!("0", Token::Unsigned(0));
+        check!("0xFF", Token::Unsigned(255));
+        check!("0xFFFFFFFFFFFFFFFF", Token::Unsigned(u64::MAX));
+        check!("18446744073709551615", Token::Unsigned(u64::MAX));
+    }
+
+    #[test]
+    fn signed() {
+        check!("+12345", Token::Signed(12345));
+        check!("-12345", Token::Signed(-12345));
+        check!("+0", Token::Signed(0));
+        check!("-0", Token::Signed(0));
+        check!("+0xFF", Token::Signed(255));
+        check!("-0xFF", Token::Signed(-255));
+
+        check!("+0x7FFFFFFFFFFFFFFF", Token::Signed(i64::MAX));
+        check!("+9223372036854775807", Token::Signed(i64::MAX));
+
+        check!("-0x7FFFFFFFFFFFFFFF", Token::Signed(i64::MIN+1));
+        check!("-9223372036854775807", Token::Signed(i64::MIN+1));
+
+        check!("-0x8000000000000000", Token::Signed(i64::MIN));
+        check!("-9223372036854775808", Token::Signed(i64::MIN));
+    }
+
+    #[test]
+    fn float() {
+        println!("PARSING: ");
+        //let x: f64 ="5.6p10".parse().unwrap();
+        //println!("RES: {}", x);
+        check!("1.1", Token::Float(1.1));
+        check!("+1.1", Token::Float(1.1));
+        check!("-1.1", Token::Float(-1.1));
+        check!("0.1", Token::Float(0.1));
+        check!("+0.1", Token::Float(0.1));
+        check!("-0.1", Token::Float(-0.1));
+        check!("10.6e5", Token::Float(10.6e5));
+        check!("10.6e-5", Token::Float(10.6e-5));
+        check!("892734987398473897410.6e-5", Token::Float(892734987398473897410.6e-5));
+        check!(
+            "892734987398473897410.656756785675678e-5", 
+            Token::Float(892734987398473897410.656756785675678e-5)
+        );
+        // check!("0xFF.FF", Token::Float(0.1));
+        // check!("+0xFF.FF", Token::Float(0.1));
+        // check!("-0.FF.FF", Token::Float(-0.1));
+        // TODO - fix parsing very large float literals
+    }
+
+    #[test]
+    fn not_numbers() {
+        check!(".");
+        check!(".1");
+        check!("12345j");
+        check!("12.345j");
+        check!("0x12345Z");
+    }
+
+    #[test]
+    fn infs() {
+        check!("inf", Token::Inf(Sign::Unspecified));
+        check!("+inf", Token::Inf(Sign::Positive));
+        check!("-inf", Token::Inf(Sign::Negative));
+    }
+
+    #[test]
+    fn nans() {
+        check!("nan", Token::NaN(Sign::Unspecified));
+        check!("+nan", Token::NaN(Sign::Positive));
+        check!("-nan", Token::NaN(Sign::Negative));
+        check!("nan:0x56", Token::NaNx(Sign::Unspecified, 0x56));
+        check!("+nan:0x56", Token::NaNx(Sign::Positive, 0x56));
+        check!("-nan:0x56", Token::NaNx(Sign::Negative, 0x56));
+    }
+}

--- a/src/format/text/lex/test.rs
+++ b/src/format/text/lex/test.rs
@@ -1,4 +1,4 @@
-use super::super::token::{FileToken, Token};
+use super::super::token::{FileToken, Token, Sign};
 use super::Tokenizer;
 use crate::error::{Result, ResultFrom};
 
@@ -17,18 +17,6 @@ macro_rules! expect_tokens {
         assert!(end.is_none(), "Expected none, got {:?}", end);
     }
 }
-
-#[cfg(test)]
-fn printout<T: AsRef<[u8]>>(to_parse: T) -> Result<()> {
-    let tokenizer = Tokenizer::new(to_parse.as_ref())?;
-
-    for token in tokenizer {
-        println!("{:?}", token.unwrap());
-    }
-
-    Ok(())
-}
-
 #[test]
 fn simple_parse() -> Result<()> {
     expect_tokens!(
@@ -58,62 +46,69 @@ fn simple_parse() -> Result<()> {
 
 #[test]
 fn bare_string() -> Result<()> {
-    printout("\"this is a string\"")
-}
-
-#[test]
-fn bare_unsigned() -> Result<()> {
-    printout("3452")?;
-    printout("0")?;
+    expect_tokens!(
+        "\"this is a 😃 string\"",
+        Token::String("this is a 😃 string".into())
+    );
     Ok(())
 }
 
 #[test]
-fn bare_signed() -> Result<()> {
-    printout("+3452")?;
-    printout("-3452")?;
-    printout("+0")?;
-    printout("-0")?;
+fn bare_integer_dec() -> Result<()> {
+    expect_tokens!("3452", Token::Unsigned(3452));
+    expect_tokens!("0", Token::Unsigned(0));
+    expect_tokens!("+3452", Token::Signed(3452));
+    expect_tokens!("-3452", Token::Signed(-3452));
+    expect_tokens!("+0", Token::Signed(0));
+    expect_tokens!("-0", Token::Signed(0));
     Ok(())
 }
 
 #[test]
-fn bare_float() -> Result<()> {
-    printout("1.5")?;
-    printout("-1.5")?;
-    printout("1.")?;
-    printout("-1.")?;
-    printout("-5e10")?;
-    printout("-5.6e10")?;
-    printout("-2.5e2")?;
-    printout("-2.5e-2")?;
+fn bare_float_dec() -> Result<()> {
+    expect_tokens!("1.5", Token::Float(1.5));
+    expect_tokens!("-1.5", Token::Float(-1.5));
+    expect_tokens!("1.", Token::Float(1.));
+    expect_tokens!("-1.", Token::Float(-1.));
+    expect_tokens!("5e5", Token::Float(500000.0));
+    expect_tokens!("-5e5", Token::Float(-500000.0));
+    expect_tokens!("2.5e6", Token::Float(2500000.0));
+    expect_tokens!("-2.5e6", Token::Float(-2500000.0));
     Ok(())
 }
 
 #[test]
-fn bare_unsigned_hex() -> Result<()> {
-    printout("0x60")?;
-    printout("0xFF")?;
-    printout("-0xFF")?;
-    printout("+0xFF")?;
-    printout("+0xFF.8p2")?;
-    printout("-0xFF.7p-2")?;
-    printout("-0xF")?;
+fn bare_integer_hex() -> Result<()> {
+    expect_tokens!("0x60", Token::Unsigned(0x60));
+    expect_tokens!("0xFF", Token::Unsigned(0xFF));
+    expect_tokens!("-0xFF", Token::Signed(-0xFF));
+    expect_tokens!("+0xFF", Token::Signed(0xFF));
+    Ok(())
+}
+
+#[test]
+fn reserved() -> Result<()> {
+    expect_tokens!("0x60z", Token::Reserved("0x60z".into()));
+    expect_tokens!("1.1asdf", Token::Reserved("1.1asdf".into()));
+    expect_tokens!("+f", Token::Reserved("+f".into()));
     Ok(())
 }
 
 #[test]
 fn nans() -> Result<()> {
-    printout("nan")?;
-    printout("inf")?;
-    printout("nan:0x56")?;
+    expect_tokens!("nan", Token::NaN(Sign::Unspecified));
+    expect_tokens!("-nan", Token::NaN(Sign::Negative));
+    expect_tokens!("+nan", Token::NaN(Sign::Positive));
+    expect_tokens!("nan:0x56", Token::NaNx(Sign::Unspecified, 0x56));
+    expect_tokens!("-nan:0x56", Token::NaNx(Sign::Negative, 0x56));
+    expect_tokens!("+nan:0x56", Token::NaNx(Sign::Positive, 0x56));
     Ok(())
 }
 
 #[test]
 fn seps() -> Result<()> {
-    printout("100_000")?;
-    printout("1.500_000_1")?;
+    expect_tokens!("100_000", Token::Unsigned(100000));
+    expect_tokens!("100_000.500_000_1", Token::Float(100000.5000001));
     Ok(())
 }
 

--- a/src/format/text/token/mod.rs
+++ b/src/format/text/token/mod.rs
@@ -22,6 +22,23 @@ impl TokenContext {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Sign {
+    Unspecified,
+    Negative,
+    Positive,
+}
+
+impl <IC:Into<char>> From<IC> for Sign {
+    fn from(ch: IC) -> Sign {
+        match ch.into() {
+            '+' => Sign::Positive,
+            '-' => Sign::Negative,
+            _ => Sign::Unspecified 
+        }
+    }
+}
+
 /// An enum of all of the possible lexical tokens that can occur in a WebAssembly text file.
 #[derive(Debug, PartialEq)]
 pub enum Token {
@@ -30,6 +47,7 @@ pub enum Token {
     LineComment,
     BlockComment,
     Keyword(String),
+    Reserved(String),
     Unsigned(u64),
     Signed(i64),
     Float(f64),
@@ -37,9 +55,9 @@ pub enum Token {
     Id(String),
     Open,
     Close,
-    Inf,
-    NaN,
-    NaNx(u32),
+    Inf(Sign),
+    NaN(Sign),
+    NaNx(Sign, u32),
     Eof
 }
 


### PR DESCRIPTION
It was a fun exercise, but real decimal float parsing is best left up to
standard libraries that properly handle rounding.

Did some more organizing and commenting of the lexing code files.