### PR TITLE
First end-to-end compiled text format example working

### DIFF
--- a/src/format/text/compile/mod.rs
+++ b/src/format/text/compile/mod.rs
@@ -1,0 +1,123 @@
+use super::syntax;
+use crate::{module, types::{FunctionType, ValueType}};
+use crate::error::{Result, ResultFrom};
+use crate::{err, error};
+use std::io::Write;
+
+impl From<syntax::FunctionType> for FunctionType {
+    fn from(ast: syntax::FunctionType) -> FunctionType {
+        FunctionType {
+            params: ast.params.iter().map(|p| p.valuetype).collect(),
+            result: ast.results.iter().map(|r| r.valuetype).collect(),
+        }
+    }
+}
+
+impl From<syntax::Local> for ValueType {
+    fn from(ast: syntax::Local) -> ValueType {
+        ast.valtype
+    }
+}
+
+impl From<syntax::ExportDesc> for module::ExportDesc {
+    fn from(ast: syntax::ExportDesc) -> module::ExportDesc {
+       match ast {
+            syntax::ExportDesc::Func(idx) => module::ExportDesc::Func(index_val(idx).unwrap()),
+            syntax::ExportDesc::Table(idx) => module::ExportDesc::Table(index_val(idx).unwrap()),
+            syntax::ExportDesc::Mem(idx) => module::ExportDesc::Memory(index_val(idx).unwrap()),
+            syntax::ExportDesc::Global(idx) => module::ExportDesc::Func(index_val(idx).unwrap())
+        }
+    }
+}
+
+fn index_val(index: syntax::Index) -> Result<u32> {
+    match index {
+        syntax::Index::Numeric(n) => Ok(n),
+        _ => err!("only numeric indices right now")
+    }
+}
+
+impl From<syntax::ExportField> for module::Export {
+    fn from(ast: syntax::ExportField) -> module::Export {
+        module::Export {
+            name: ast.name,
+            desc: ast.exportdesc.into()
+        }
+    }
+}
+
+fn compile_function_body(func: &syntax::FuncField) -> Result<Box<[u8]>> {
+    let mut body: Vec<u8> = Vec::new();
+
+    for instr in &func.body.instr {
+        // Emit opcode
+        body.write(&[instr.opcode]).wrap("writing opcode")?;
+        // Emit operands
+        match instr.operands {
+            syntax::Operands::None => (),
+            syntax::Operands::I32(n) |
+            syntax::Operands::Index(syntax::Index::Numeric(n)) => {
+                let bytes = &n.to_le_bytes()[..];
+                body.write(&bytes).wrap("writing index operand")?;
+            }
+            _ => ()
+        }
+    }
+    // ???
+    // profit!
+    Ok(body.into_boxed_slice())
+}
+
+fn compile_function(
+    func: syntax::FuncField,
+    types: &[FunctionType],
+) -> Result<module::Function> {
+
+    // Get the typeidx from the finalized list of types
+    let functype = match func.typeuse.typeidx {
+        Some(syntax::Index::Numeric(idx)) => Ok(idx),
+        Some(syntax::Index::Named(_)) => err!("ids lookup not done"),
+        None => {
+            let inline_def = &func.typeuse.get_inline_def().unwrap().into();
+            types.iter()
+                .position(|t| t == inline_def)
+                .map(|p| p as u32)
+                .ok_or_else(|| error!("inline type missing from type list. this is a compiler error."))
+        }
+    }?;
+
+    // Convert the locals into a normal box
+    let locals: Box<[ValueType]> = func.locals.iter().map(|l| l.valtype).collect();
+
+    let body = compile_function_body(&func)?;
+
+    // Compile the method body!!
+    Ok(module::Function {
+        functype,
+        locals,
+        body
+    })
+}
+
+pub fn compile(ast: syntax::Module) -> Result<module::Module> {
+
+    let types: Box<[FunctionType]> = 
+        ast.types.into_iter().map(|t| t.functiontype.into()).collect();
+
+    let exports = ast.exports.into_iter().map(|e| e.into()).collect();
+
+    // Needed: 
+    // * completed types list,
+    // * completed index table,
+    let funcs = ast.funcs
+        .into_iter()
+        .map(|f| compile_function(f, &types))
+        .collect::<Result<Box<[module::Function]>>>()?;
+
+    Ok(module::Module {
+        types,
+        funcs, 
+        exports,
+        ..module::Module::default()
+    })
+}

--- a/src/format/text/mod.rs
+++ b/src/format/text/mod.rs
@@ -5,3 +5,4 @@ pub mod parse;
 pub mod syntax;
 pub mod module_builder;
 pub mod macros;
+pub mod compile;

--- a/src/format/text/parse/instruction.rs
+++ b/src/format/text/parse/instruction.rs
@@ -30,10 +30,10 @@ impl<R: Read> Parser<R> {
                     Operands::GlobalIndex => { 
                         syntax::Operands::Index(self.parse_index()?)
                     }
-                    Operands::I32 | Operands::I64 | 
-                    Operands::F32 | Operands::F64 => { 
-                        syntax::Operands::Number(self.expect_number()?)
-                    }, 
+                    Operands::I32 => syntax::Operands::I32(self.expect_number()? as u32),
+                    Operands::I64 => syntax::Operands::I64(self.expect_number()? as u64),
+                    Operands::F32 => syntax::Operands::F32(self.expect_number()? as f32),
+                    Operands::F64 => syntax::Operands::F64(self.expect_number()? as f64),
                     Operands::Memargs => { 
                         let align = self.try_align()?.unwrap_or(0);
                         let offset = self.try_offset()?.unwrap_or(0); 
@@ -41,7 +41,7 @@ impl<R: Read> Parser<R> {
                     },
                     _ => return err!("Unimplemented operands type {:?}", data.operands)
                 };
-                Ok(Some(Instruction{name, operands}))
+                Ok(Some(Instruction{name, opcode: data.opcode, operands}))
             },
             None => err!("bad instruction name {}", name)
         }

--- a/src/format/text/parse/module.rs
+++ b/src/format/text/parse/module.rs
@@ -256,12 +256,38 @@ impl<R: Read> Parser<R> {
             return Ok(None);
         }
 
-        self.consume_expression()?;
-        println!("COMPLETED EXPORTFIELD");
+        let name = self.expect_string()?;
+
+        let exportdesc = self.expect_exportdesc()?;
+
+        self.expect_close()?;
+
         Ok(Some(Field::Export(ExportField {
-            name: "name".into(),
-            exportdesc: ExportDesc::Func(Index::Numeric(0)),
+            name,
+            exportdesc,
         })))
+    }
+
+    fn expect_exportdesc(&mut self) -> Result<ExportDesc> {
+        if self.try_expr_start("func")? {
+            let index = self.parse_index()?;
+            self.expect_close()?;
+            Ok(ExportDesc::Func(index))
+        } else if self.try_expr_start("table")? {
+            let index = self.parse_index()?;
+            self.expect_close()?;
+            Ok(ExportDesc::Table(index))
+        } else if self.try_expr_start("memory")? {
+            let index = self.parse_index()?;
+            self.expect_close()?;
+            Ok(ExportDesc::Mem(index))
+        } else if self.try_expr_start("global")? {
+            let index = self.parse_index()?;
+            self.expect_close()?;
+            Ok(ExportDesc::Global(index))
+        } else {
+            err!("no valid importdesc found")
+        }
     }
 
     pub fn try_global_field(&mut self) -> Result<Option<Field>> {

--- a/src/format/text/syntax.rs
+++ b/src/format/text/syntax.rs
@@ -369,6 +369,7 @@ impl fmt::Debug for Expr {
 #[derive(PartialEq)]
 pub struct Instruction {
     pub name: String,
+    pub opcode: u8,
     pub operands: Operands
 }
 
@@ -377,7 +378,10 @@ pub enum Operands {
     None,
     Index(Index),
     Memargs(u32, u32),
-    Number(u64),
+    I32(u32),
+    I64(u64),
+    F32(f32),
+    F64(f64)
 }
 
 impl std::fmt::Debug for Instruction {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,3 +5,4 @@ mod meminstr64;
 mod memoffset;
 mod parse;
 mod spec_parse;
+mod parse_and_run;

--- a/tests/parse_and_run.rs
+++ b/tests/parse_and_run.rs
@@ -1,0 +1,27 @@
+use wrausmt::format::text::parse::Parser;
+use wrausmt::format::text::compile::compile;
+use wrausmt::format::text::lex::Tokenizer;
+use wrausmt::error::{Result, ResultFrom};
+use wrausmt::runtime::Runtime;
+
+#[test]
+fn simplefunc() -> Result<()> {
+    let f = std::fs::File::open("testdata/simplefunc.wat").wrap("opening file")?;
+
+    let tokenizer = Tokenizer::new(f)?;
+    let mut parser = Parser::new(tokenizer)?;
+    let ast = parser.try_module()?.unwrap();
+    
+    println!("AST! {:?}", ast);
+    let module = compile(ast)?;
+    
+    println!("MODULE! {:?}", module);
+
+    let mut runtime = Runtime::new();
+    let mod_inst = runtime.load(module)?;
+
+    let res1 = runtime.call(&mod_inst, "test", &[100u32.into()])?;
+    assert_eq!(res1, 142u32.into());
+
+    Ok(())
+}


### PR DESCRIPTION
* Add parsing support for export fields
* Get more specific about the types for value operands.
* Implement enough of the compiler to get types, funcs, and exports.