### PR TITLE
Implement support for tracking and resolving IDs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 ## Rough task list
 
+* Make a macro to unify try/expect parser pattern
 * Improve error structuring
 * Generate instruction name tables
 * Add better execution tracing & control
@@ -18,5 +19,3 @@
 * Pass WASM test suite
 * Benchmarks
 * Binary format emitter (from module)
-
-

--- a/src/format/text/ID.md
+++ b/src/format/text/ID.md
@@ -1,0 +1,59 @@
+# Notes on ID scoping and usage
+
+## MODULE SCOPE
+
+Module-scoped IDs may be used at any point in the file. These are tracked in a
+map along with the module syntax element as it is created.
+
+### Type IDs
+Usages:
+* Func TypeUse
+* Import Func TypeUse
+
+### Func IDs
+Usages:
+* Function Body: call, ref.func
+* Export Func 
+* Element List
+* Start
+
+### Table IDs
+Usages:
+* Function Body: call\_indirect, table.\*
+* Export Table
+* Elem Segments
+
+### Memory IDs
+Note: Always 0 in current spec
+
+Usages:
+* Export Mem
+* Data Segments
+
+### Global IDs
+* Funcion Body: global.\*
+* Export Global
+
+### Elem IDs
+* Function Body: elem.drop, table.init
+
+### Data IDs
+* Function Body: data.drop, mem.init
+
+## FUNCTION SCOPE
+
+Function scoped IDs are only referenced from within the scope of the function,
+so the tracking of these is easier.
+
+### Local IDs
+Function Body: local.\*
+
+## BLOCK SCOPE
+
+Block scope identifiers are tracked only with the scope of a function. However,
+labels are counted from the inside out, so the binding of a particular ID name
+may change as block nesting gets deeper.
+
+### Label IDs
+Function Body: br, br_if, br_table
+

--- a/src/format/text/mod.rs
+++ b/src/format/text/mod.rs
@@ -6,3 +6,4 @@ pub mod syntax;
 pub mod module_builder;
 pub mod macros;
 pub mod compile;
+pub mod resolve;

--- a/src/format/text/module_builder.rs
+++ b/src/format/text/module_builder.rs
@@ -1,60 +1,113 @@
-use super::syntax::{DataField, ElemField, ExportDesc, ExportField, FuncField, FunctionType, GlobalField, ImportDesc, ImportField, Index, MemoryField, Module, StartField, TableField, TypeField};
+use std::collections::HashMap;
 
+use super::{resolve::{IdentifierContext, Resolve}, syntax::{
+    DataField, ElemField, ExportDesc, ExportField, FuncField, FunctionType, GlobalField,
+    ImportDesc, ImportField, Index, MemoryField, Module, Resolved, StartField, TableField,
+    TypeField, Unresolved
+}};
+use crate::error::Result;
+
+/// A [ModuleBuilder] accepts the various [Field] items coming from the parse, and organizes them
+/// by sections into a [Module]. This [Module] is still just an abstract representation. ID
+/// declarations  are collected into maps, but ID usages are not yet resolved. ID resolution and
+/// function body compilation happens in a subsequent resolution pass.
+#[derive(Debug, Default)]
 pub struct ModuleBuilder {
-    module: Module
+    module: Module<Unresolved>,
+    funcidx_offset: u32,
+    tableidx_offset: u32,
+    memidx_offset: u32,
+    globalidx_offset: u32,
+}
 
+macro_rules! add_ident {
+    ( $self:ident, $field:ident, $dst:ident, $src:ident, $offset:expr) => {
+        if let Some(id) = &$field.id {
+            $self
+                .module
+                .identifiers
+                .$dst
+                .insert(id.clone(), $self.module.$src.len() as u32 + $offset);
+        }
+    };
 }
 
 impl ModuleBuilder {
     pub fn new(id: Option<String>) -> Self {
         Self {
             module: Module {
-                id, 
+                id,
                 ..Module::default()
-            }
+            },
+            ..ModuleBuilder::default()
         }
     }
 
-    pub fn build(self) -> Module {
-        self.module
+    pub fn build(mut self) -> Result<Module<Resolved>> {
+        // This is just a placeholder until resolution is implemented.
+        // Since the ResolvedState is only used as a PhantomData marker,
+        // the bit pattern is the same.
+        // This is indeed unsafe; the symbolic indexes will not have been resolved, so any
+        // references to them in the module body will be incorrect.
+        let empty: HashMap<String, u32> = HashMap::default();
+        let modulescope = std::mem::take(&mut self.module.identifiers);
+        let ic = IdentifierContext {
+            modulescope: &modulescope,
+            localindices: &empty,
+            labelindices: &empty
+        };
+        println!("RESOLVE WITH {:?}", ic);
+        self.module.resolve(&ic)
     }
 
     pub fn add_typefield(&mut self, typefield: TypeField) {
+        add_ident!(self, typefield, typeindices, types, 0);
         self.module.types.push(typefield);
     }
 
     pub fn add_inline_typeuse(&mut self, functiontype: FunctionType) {
-        if self.module.types.iter().position(|t| t.functiontype == functiontype).is_none() {
+        if self
+            .module
+            .types
+            .iter()
+            .position(|t| t.functiontype == functiontype)
+            .is_none()
+        {
             self.module.types.push(TypeField {
                 id: None,
-                functiontype
+                functiontype,
             })
         }
     }
 
-    pub fn add_funcfield(&mut self, f: FuncField) {
+    pub fn add_funcfield(&mut self, f: FuncField<Unresolved>) {
         // type use may define new type
         if let Some(inline_typefield) = f.typeuse.get_inline_def() {
             self.add_inline_typeuse(inline_typefield)
         }
+
+        add_ident!(self, f, funcindices, funcs, self.funcidx_offset);
+
         // export field may define new exports.
         let funcidx = self.module.funcs.len() as u32;
         for export_name in &f.exports {
             self.module.exports.push(ExportField {
                 name: export_name.clone(),
-                exportdesc: ExportDesc::Func(Index::Numeric(funcidx)),
+                exportdesc: ExportDesc::Func(Index::unnamed(funcidx)),
             })
         }
         self.module.funcs.push(f);
     }
 
-    pub fn add_tablefield(&mut self, f: TableField) {
+    pub fn add_tablefield(&mut self, f: TableField<Unresolved>) {
+        add_ident!(self, f, tableindices, tables, self.tableidx_offset);
+
         // export field may define new exports.
         let tableidx = self.module.funcs.len() as u32;
         for export_name in &f.exports {
             self.module.exports.push(ExportField {
                 name: export_name.clone(),
-                exportdesc: ExportDesc::Table(Index::Numeric(tableidx)),
+                exportdesc: ExportDesc::Table(Index::unnamed(tableidx)),
             })
         }
         // TODO elem contents may define new elem
@@ -62,53 +115,71 @@ impl ModuleBuilder {
     }
 
     pub fn add_memoryfield(&mut self, f: MemoryField) {
+        add_ident!(self, f, memindices, memories, self.memidx_offset);
+
         // export field may define new exports.
         let memidx = self.module.funcs.len() as u32;
         for export_name in &f.exports {
             self.module.exports.push(ExportField {
                 name: export_name.clone(),
-                exportdesc: ExportDesc::Mem(Index::Numeric(memidx)),
+                exportdesc: ExportDesc::Mem(Index::unnamed(memidx)),
             })
         }
         self.module.memories.push(f);
         // data contents may define new data
     }
 
-    pub fn add_importfield(&mut self, f: ImportField) {
-        // Function import may define a new type.
-        if let ImportDesc::Func(tu) = &f.desc {
-            if let Some(inline_typefield) = tu.get_inline_def() {
-                self.add_inline_typeuse(inline_typefield)
+    pub fn add_importfield(&mut self, f: ImportField<Unresolved>) {
+        // Imports contribute to index counts in their corresponding
+        // space, and must appear before any declarations of that type
+        // in the module, so we track their counts of each type in order
+        // to adjust indices.
+        match &f.desc {
+            ImportDesc::Func(tu) => {
+                // Function import may define a new type.
+                if let Some(inline_typefield) = tu.get_inline_def() {
+                    self.add_inline_typeuse(inline_typefield)
+                }
+                self.funcidx_offset += 1
             }
+            ImportDesc::Mem(_) => self.memidx_offset += 1,
+            ImportDesc::Table(_) => self.tableidx_offset += 1,
+            ImportDesc::Global(_) => self.globalidx_offset += 1,
         }
         self.module.imports.push(f);
     }
 
-    pub fn add_exportfield(&mut self, f: ExportField) {
+    pub fn add_exportfield(&mut self, f: ExportField<Unresolved>) {
         self.module.exports.push(f)
     }
 
-    pub fn add_globalfield(&mut self, f: GlobalField) {
+    pub fn add_globalfield(&mut self, f: GlobalField<Unresolved>) {
+        add_ident!(self, f, globalindices, globals, self.globalidx_offset);
+
         let globalidx = self.module.funcs.len() as u32;
         for export_name in &f.exports {
             self.module.exports.push(ExportField {
                 name: export_name.clone(),
-                exportdesc: ExportDesc::Mem(Index::Numeric(globalidx))
+                exportdesc: ExportDesc::Mem(Index::unnamed(globalidx)),
             })
         }
         // export field may define new exports.
         self.module.globals.push(f);
     }
 
-    pub fn add_startfield(&mut self, f: StartField) {
+    pub fn add_startfield(&mut self, f: StartField<Unresolved>) {
         self.module.start = Some(f)
     }
 
-    pub fn add_elemfield(&mut self, f: ElemField) {
+    pub fn add_elemfield(&mut self, f: ElemField<Unresolved>) {
+        add_ident!(self, f, elemindices, elems, 0);
+
         self.module.elems.push(f)
     }
 
-    pub fn add_datafield(&mut self, f: DataField) {
-        self.module.data.push(f) 
+    pub fn add_datafield(&mut self, f: DataField<Unresolved>) {
+        add_ident!(self, f, dataindices, data, 0);
+
+        self.module.data.push(f)
     }
 }

--- a/src/format/text/resolve.rs
+++ b/src/format/text/resolve.rs
@@ -1,0 +1,313 @@
+//! Methods implementing index usage resolution.
+use std::collections::HashMap;
+
+use crate::error;
+use crate::error::Result;
+use super::syntax::{DataField, DataIndex, DataInit, ElemField, ElemIndex, ElemList, ExportDesc, ExportField, Expr, FuncField, FuncIndex, GlobalField, GlobalIndex, ImportDesc, ImportField, Index, Instruction, LabelIndex, LocalIndex, MemoryIndex, ModeEntry, Module, ModuleIdentifiers, Operands, Resolved, StartField, TableElems, TableField, TableIndex, TablePosition, TableUse, TypeIndex, TypeUse, Unresolved};
+
+/// A structure to hold the currently resolvable set of identifiers.
+#[derive(Debug)]
+pub struct IdentifierContext<'a> {
+    pub modulescope: &'a ModuleIdentifiers,
+    pub localindices: &'a HashMap<String, u32>,
+    pub labelindices: &'a HashMap<String, u32> 
+}
+
+/// Each syntax element that contains an index usag, an element containin an index
+/// usage, should implement this trait with logic describing how to return the 
+/// element in a resolved state.
+pub trait Resolve<T> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<T>;
+}
+
+/// For an iterable of unresolved items, returns a Vector with all of the items resolved.
+macro_rules! resolve_all {
+    ( $dst:ident, $src:expr, $ic:expr ) => {
+        let $dst: Result<Vec<_>> = $src.into_iter().map(|i| i.resolve(&$ic)).collect();
+
+    }
+}
+
+/// For an option of an unresolved items, returns an option of the resolved item.
+macro_rules! resolve_option {
+    ( $dst:ident, $src:expr, $ic:expr ) => {
+        let $dst = $src.map(|i| i.resolve(&$ic)).transpose()?;
+    }
+}
+
+/// This generates each of the [Resolve] impls for the [Index] in each [IndexSpace].
+macro_rules! index_resolver {
+    ( $it:ty, $ic:ident, $src:expr  ) => {
+        impl Resolve<Index<Resolved, $it>> for Index<Unresolved, $it> {
+            fn resolve(self, $ic: &IdentifierContext) -> Result<Index<Resolved, $it>> {
+                let value = if self.name.is_empty() {
+                    self.value
+                } else {
+                    // TODO - how to handle the different index types?
+                    let value = $src.get(&self.name)
+                        .ok_or_else(|| error!("id not found {}", self.name))?;
+                    *value
+                };
+                Ok(self.resolved(value))
+            }
+        }
+    }
+}
+
+index_resolver!{TypeIndex, ic, ic.modulescope.typeindices}
+index_resolver!{FuncIndex, ic, ic.modulescope.funcindices}
+index_resolver!{TableIndex, ic, ic.modulescope.tableindices}
+index_resolver!{GlobalIndex, ic, ic.modulescope.globalindices}
+index_resolver!{MemoryIndex, ic, ic.modulescope.memindices}
+index_resolver!{ElemIndex, ic, ic.modulescope.elemindices}
+index_resolver!{DataIndex, ic, ic.modulescope.dataindices}
+index_resolver!{LocalIndex, ic, ic.localindices}
+index_resolver!{LabelIndex, ic, ic.labelindices}
+
+impl Resolve<Expr<Resolved>> for Expr<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<Expr<Resolved>> {
+        resolve_all!(instr, self.instr, ic);
+        Ok(Expr {
+            instr: instr?
+        })
+    }
+}
+
+impl Resolve<Instruction<Resolved>> for Instruction<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<Instruction<Resolved>> {
+        Ok(Instruction{
+            name: self.name,
+            opcode: self.opcode,
+            operands: self.operands.resolve(&ic)?
+        })
+    }
+}
+
+impl Resolve<Operands<Resolved>> for Operands<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<Operands<Resolved>> {
+        Ok(
+        match self {
+            Operands::None => Operands::None,
+            Operands::FuncIndex(idx) => Operands::FuncIndex(idx.resolve(&ic)?),
+            Operands::TableIndex(idx) => Operands::TableIndex(idx.resolve(&ic)?),
+            Operands::GlobalIndex(idx) => Operands::GlobalIndex(idx.resolve(&ic)?),
+            Operands::ElemIndex(idx) => Operands::ElemIndex(idx.resolve(&ic)?),
+            Operands::DataIndex(idx) => Operands::DataIndex(idx.resolve(&ic)?),
+            Operands::LocalIndex(idx) => Operands::LocalIndex(idx.resolve(&ic)?),
+            Operands::LabelIndex(idx) => Operands::LabelIndex(idx.resolve(&ic)?),
+            Operands::Memargs(a, o) => Operands::Memargs(a, o),
+            Operands::I32(v) => Operands::I32(v),
+            Operands::I64(v) => Operands::I64(v),
+            Operands::F32(v) => Operands::F32(v),
+            Operands::F64(v) => Operands::F64(v),
+        })
+    }
+}
+
+impl Resolve<TableField<Resolved>> for TableField<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<TableField<Resolved>> {
+        resolve_option!(elems, self.elems, ic);
+        Ok(TableField {
+            id: self.id,
+            exports: self.exports,
+            tabletype: self.tabletype,
+            elems 
+        })
+    }
+}
+
+impl Resolve<TableElems<Resolved>> for TableElems<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<TableElems<Resolved>> {
+        Ok(match self {
+            TableElems::Elem(el) => TableElems::Elem(el.resolve(&ic)?),
+            TableElems::Expr(exprs) => {
+                resolve_all!(e, exprs, ic);
+                TableElems::Expr(e?)
+            }
+        })
+    }
+}
+
+impl Resolve<ElemList<Resolved>> for ElemList<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<ElemList<Resolved>> {
+        resolve_all!(items, self.items, ic);
+        Ok(ElemList{
+            reftype: self.reftype,
+            items: items?
+        })
+    }
+}
+
+impl Resolve<ImportField<Resolved>> for ImportField<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<ImportField<Resolved>> {
+        Ok(ImportField {
+            modname: self.modname,
+            name: self.name,
+            id: self.id,
+            desc: self.desc.resolve(&ic)?
+        })
+    }
+}
+
+impl Resolve<ImportDesc<Resolved>> for ImportDesc<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<ImportDesc<Resolved>> {
+        Ok(match self {
+            ImportDesc::Func(tu) => ImportDesc::Func(tu.resolve(&ic)?),
+            ImportDesc::Table(tt) => ImportDesc::Table(tt),
+            ImportDesc::Mem(mt) => ImportDesc::Mem(mt),
+            ImportDesc::Global(gt) => ImportDesc::Global(gt)
+        })
+    }
+}
+
+impl Resolve<ExportField<Resolved>> for ExportField<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<ExportField<Resolved>> {
+        Ok(ExportField{
+            name: self.name,
+            exportdesc: self.exportdesc.resolve(&ic)?
+        })
+    }
+}
+
+impl Resolve<ExportDesc<Resolved>> for ExportDesc<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<ExportDesc<Resolved>> {
+        Ok(match self {
+            ExportDesc::Func(idx) => ExportDesc::Func(idx.resolve(&ic)?),
+            ExportDesc::Table(idx) => ExportDesc::Table(idx.resolve(&ic)?),
+            ExportDesc::Mem(idx) => ExportDesc::Mem(idx.resolve(&ic)?),
+            ExportDesc::Global(idx) => ExportDesc::Global(idx.resolve(&ic)?),
+        })
+    }
+}
+
+impl Resolve<GlobalField<Resolved>> for GlobalField<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<GlobalField<Resolved>> {
+        Ok(GlobalField{
+            id: self.id,
+            exports: self.exports,
+            globaltype: self.globaltype,
+            init: self.init.resolve(&ic)?
+        })
+    }
+}
+
+impl Resolve<StartField<Resolved>> for StartField<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<StartField<Resolved>> {
+        Ok(StartField{
+            idx: self.idx.resolve(&ic)?
+        })
+    }
+}
+
+impl Resolve<ElemField<Resolved>> for ElemField<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<ElemField<Resolved>> {
+        Ok(ElemField{
+            id: self.id,
+            mode: self.mode.resolve(&ic)?,
+            elemlist: self.elemlist.resolve(&ic)?
+        })
+    }
+}
+
+impl Resolve<ModeEntry<Resolved>> for ModeEntry<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<ModeEntry<Resolved>> {
+        Ok(match self {
+            ModeEntry::Passive => ModeEntry::Passive,
+            ModeEntry::Active(tp) => ModeEntry::Active(tp.resolve(&ic)?),
+            ModeEntry::Declarative => ModeEntry::Declarative
+        })
+    }
+}
+
+impl Resolve<TablePosition<Resolved>> for TablePosition<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<TablePosition<Resolved>> {
+        Ok(TablePosition{
+            tableuse: self.tableuse.resolve(&ic)?,
+            offset: self.offset.resolve(&ic)?
+        })
+    }
+}
+
+impl Resolve<TableUse<Resolved>> for TableUse<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<TableUse<Resolved>> {
+        Ok(TableUse{
+            tableidx: self.tableidx.resolve(&ic)?
+        })
+    }
+}
+
+impl Resolve<DataField<Resolved>> for DataField<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<DataField<Resolved>> {
+        resolve_option!(init, self.init, ic);
+        Ok(DataField{
+            id: self.id,
+            data: self.data,
+            init
+        })
+    }
+}
+
+impl Resolve<DataInit<Resolved>> for DataInit<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<DataInit<Resolved>> {
+        Ok(DataInit {
+            memidx: self.memidx.resolve(&ic)?,
+            offset: self.offset.resolve(&ic)?
+        })
+    }
+}
+
+impl Resolve<Module<Resolved>> for Module<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<Module<Resolved>> {
+        resolve_all!(funcs, self.funcs, ic);
+        resolve_all!(tables, self.tables, ic);
+        resolve_all!(imports, self.imports, ic);
+        resolve_all!(exports, self.exports, ic);
+        resolve_all!(globals, self.globals, ic);
+        resolve_all!(elems, self.elems, ic);
+        resolve_option!(start, self.start, ic);
+        resolve_all!(data, self.data, ic);
+        Ok(Module {
+            id: self.id,
+            types: self.types,
+            funcs: funcs?,
+            tables: tables?,
+            memories: self.memories,
+            imports: imports?,
+            exports: exports?,
+            globals: globals?,
+            start,
+            elems: elems?,
+            data: data?,
+            identifiers: self.identifiers
+        })
+    }
+}
+
+impl Resolve<TypeUse<Resolved>> for TypeUse<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<TypeUse<Resolved>> {
+        resolve_option!(typeidx, self.typeidx, ic);
+        Ok(TypeUse { typeidx, functiontype: self.functiontype })
+    }
+}
+
+impl Resolve<FuncField<Resolved>> for FuncField<Unresolved> {
+    fn resolve(self, ic: &IdentifierContext) -> Result<FuncField<Resolved>> {
+        let typeuse = self.typeuse.resolve(&ic)?;
+
+        let fic = IdentifierContext {
+            modulescope: ic.modulescope,
+            localindices: &self.localindices,
+            labelindices: ic.labelindices
+        };
+        let body = self.body.resolve(&fic)?;
+
+        Ok(FuncField {
+            id: self.id,
+            exports: self.exports,
+            typeuse,
+            locals: self.locals,
+            body,
+            localindices: self.localindices
+        })
+    }
+}

--- a/src/spec/format/mod.rs
+++ b/src/spec/format/mod.rs
@@ -1,4 +1,4 @@
-use crate::{format::text::parse::Parser, types::{NumType, RefType}};
+use crate::{format::text::{parse::Parser, syntax::Resolved}, types::{NumType, RefType}};
 use crate::format::text::token::Token;
 use std::io::Read;
 use crate::error::Result;
@@ -325,7 +325,7 @@ pub enum Cmd {
 ///   ( module <name>? quote <string>* )         ;; module quoted in text (may be malformed)
 #[derive(Debug)]
 pub enum Module {
-    Module(modulesyntax::Module),
+    Module(modulesyntax::Module<Resolved>),
     Binary(Vec<String>),
     Quote(Vec<String>)
 }

--- a/testdata/locals.wat
+++ b/testdata/locals.wat
@@ -8,7 +8,6 @@
   (import "env" "__memory_base" (global (;1;) i32))
   (import "env" "__table_base" (global (;2;) i32))
   (import "env" "memory" (memory (;0;) 0))
-  (func $inline-import (import "mod" "fooimport") (type 1) (param $go i32) (result f32))
   (func $init (type 2) (param i32) 
     call 2)
   (func (type $void))
@@ -16,16 +15,17 @@
     (local i32)
     i32.const 600
     local.set 1
-    local.get $foo 
     (i32.add (i32.const 2) (i32.const 4))
     local.get 1
     i32.sub
+    local.get 0
+    i32.add
     return)
   (func $inline-export (export "fooexport") (result i32)
     i32.const 45)
   ;; Inline type
   (global (;3;) i32 (i32.const 0))
   (export "__post_instantiate" (func 0))
-  (export "test" (func 2))
+  (export "test" (func $foo))
   (export "__dso_handle" (global 3))
   (export "__wasm_apply_data_relocs" (func 1)))

--- a/tests/parse_and_run.rs
+++ b/tests/parse_and_run.rs
@@ -25,3 +25,25 @@ fn simplefunc() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn locals() -> Result<()> {
+    let f = std::fs::File::open("testdata/locals.wat").wrap("opening file")?;
+
+    let tokenizer = Tokenizer::new(f)?;
+    let mut parser = Parser::new(tokenizer)?;
+    let ast = parser.try_module()?.unwrap();
+    
+    println!("AST! {:?}", ast);
+    let module = compile(ast)?;
+    
+    println!("MODULE! {:?}", module);
+
+    let mut runtime = Runtime::new();
+    let mod_inst = runtime.load(module)?;
+
+    let res1 = runtime.call(&mod_inst, "test", &[105u32.into()])?;
+    assert_eq!(res1, 699u32.into());
+
+    Ok(())
+}


### PR DESCRIPTION
* Syntax items now have two typestates: resolved, unresolved.
* Module identifiers are tracked along with the syntax element that
  matches their scope.