### PR TITLE
Improve index safety

### DIFF
--- a/src/format/text/indices.rs
+++ b/src/format/text/indices.rs
@@ -1,0 +1,46 @@
+/// ResolvedState is used to track whether or not the symbolic indices in the module have been
+/// resolved into the proper numeric values. This needs to happen in a second pass after the
+/// initial parse, since index usage may occur before the index has been defined.
+///
+pub trait ResolvedState : std::fmt::Debug {}
+
+/// A module parameterized by the [Resolved] type will have undergone index resolution, and should
+/// be safe to compile further.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Resolved {}
+impl ResolvedState for Resolved {}
+
+/// A module parameterized by the [Resolved] type will have undergone index resolution, and must be
+/// compiled before it can be used by the runtime.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Unresolved {}
+impl ResolvedState for Unresolved {}
+
+pub trait IndexSpace {}
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct FuncIndex {}
+impl IndexSpace for FuncIndex {}
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TypeIndex {}
+impl IndexSpace for TypeIndex {}
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TableIndex {}
+impl IndexSpace for TableIndex {}
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct GlobalIndex {}
+impl IndexSpace for GlobalIndex {}
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct MemoryIndex {}
+impl IndexSpace for MemoryIndex {}
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DataIndex {}
+impl IndexSpace for DataIndex {}
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ElemIndex {}
+impl IndexSpace for ElemIndex {}
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct LocalIndex {}
+impl IndexSpace for LocalIndex {}
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct LabelIndex {}
+impl IndexSpace for LabelIndex {}

--- a/src/format/text/mod.rs
+++ b/src/format/text/mod.rs
@@ -7,3 +7,4 @@ pub mod module_builder;
 pub mod macros;
 pub mod compile;
 pub mod resolve;
+pub mod indices;

--- a/src/format/text/resolve.rs
+++ b/src/format/text/resolve.rs
@@ -40,12 +40,12 @@ macro_rules! index_resolver {
     ( $it:ty, $ic:ident, $src:expr  ) => {
         impl Resolve<Index<Resolved, $it>> for Index<Unresolved, $it> {
             fn resolve(self, $ic: &IdentifierContext) -> Result<Index<Resolved, $it>> {
-                let value = if self.name.is_empty() {
-                    self.value
+                let value = if self.name().is_empty() {
+                    self.value()
                 } else {
                     // TODO - how to handle the different index types?
-                    let value = $src.get(&self.name)
-                        .ok_or_else(|| error!("id not found {}", self.name))?;
+                    let value = $src.get(self.name())
+                        .ok_or_else(|| error!("id not found {}", self.name()))?;
                     *value
                 };
                 Ok(self.resolved(value))


### PR DESCRIPTION
* Move index into its own package, and control access to the name and
  value fields so that they can only be modified in accordance with
  ResolvedState