### PR TITLE
Stop storing module::Function in FunctionInstance

### DIFF
--- a/src/runtime/instance/function_instance.rs
+++ b/src/runtime/instance/function_instance.rs
@@ -1,4 +1,4 @@
-use crate::error::{Result, ResultFrom};
+use crate::{error::{Result, ResultFrom}, instructions::Expr, types::ValueType};
 use crate::module::Function;
 use crate::runtime::error::ArgumentCountError;
 use crate::runtime::instance::ModuleInstance;
@@ -19,7 +19,15 @@ use crate::error;
 pub struct FunctionInstance {
     pub functype: FunctionType,
     pub module_instance: RefCell<Option<Rc<ModuleInstance>>>,
-    pub code: Function,
+    
+    /// The locals declare a vector of mutable local variables and their types. These variables are
+    /// referenced through local indices in the function's body. The index of the first local is
+    /// the smallest index not referencing a parameter.
+    pub locals: Box<[ValueType]>,
+
+    /// The body is an instruction sequence that upon termination must produce a stack matching the
+    /// function type's result type.
+    pub body: Box<Expr>,
 }
 
 /// A host function is a function expressed outside WebAssembly but passed to a
@@ -41,7 +49,8 @@ impl FunctionInstance {
         FunctionInstance {
             functype: types[func.functype as usize].clone(),
             module_instance: RefCell::new(None),
-            code: func,
+            locals: func.locals,
+            body: func.body
         }
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -166,13 +166,13 @@ impl Runtime {
         // 12. Enter the instruction sequence with the label.
         let label = Label {
             arity: funcinst.functype.result.len() as u32,
-            continuation: funcinst.code.body.len() as u32,
+            continuation: funcinst.body.len() as u32,
         };
         
         
         self.stack.push_label(label)?;
 
-        self.enter(&funcinst.code.body)?;
+        self.enter(&funcinst.body)?;
         
         // NOTE: The compiled function has an `end` instruction at the end
         // which takes care of popping the label.
@@ -181,7 +181,7 @@ impl Runtime {
         self.stack.pop_activation()?;
 
         println!("REMOVE FRAME {} {} {}", 
-            funcinst.code.locals.len(),
+            funcinst.locals.len(),
             funcinst.functype.params.len(),
             funcinst.functype.result.len(),
         );

--- a/src/runtime/stack.rs
+++ b/src/runtime/stack.rs
@@ -75,7 +75,7 @@ impl Stack {
     pub fn push_activation(&mut self, funcinst: &FunctionInstance) -> Result<()> {
         let frame_start = self.value_stack.len() - funcinst.functype.params.len();
         // 8. Let val0* be the list of zero values (other locals). 
-        for localtype in funcinst.code.locals.iter() {
+        for localtype in funcinst.locals.iter() {
             self.push_value(localtype.default());
         }
         println!("FRAME START: {}", frame_start);


### PR DESCRIPTION
Preparing for eventual removal of the module package's pseudo-syntax.