### PR TITLE
Instantiate modules in the runtime directly from the AST-syntax

### DIFF
--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -6,7 +6,6 @@ use crate::format::error::ParseError as BinaryParseError;
 use crate::format::text::lex::error::LexError;
 use crate::format::text::parse::Parser;
 use crate::runtime::{Runtime, instance::ModuleInstance};
-use crate::format::text::compile::compile;
 use crate::error::Error;
 
 #[derive(Debug)]
@@ -77,11 +76,9 @@ impl Loader for Runtime {
     fn load_wast(&mut self, filename: &str) -> Result<Rc<ModuleInstance>> {
         let ast = load_ast(filename)?;
     
-        let module = compile(ast);
-
-        println!("MODULE {:#?}", module);
+        println!("MODULE {:#?}", ast);
     
-        let mod_inst = self.load(module)?;
+        let mod_inst = self.load_ast(ast)?;
         Ok(mod_inst)
     }
 

--- a/src/spec/runner.rs
+++ b/src/spec/runner.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use super::format::{Action, ActionResult, SpecTestScript};
-use crate::{err, error::Result, format::text::compile::compile, runtime::{Runtime, instance::ModuleInstance, values::{Num, Ref, Value}}, spec::format::{Assertion, Cmd, Module}};
+use crate::{err, error::Result, runtime::{Runtime, instance::ModuleInstance, values::{Num, Ref, Value}}, spec::format::{Assertion, Cmd, Module}};
 
 
 fn handle_action(
@@ -68,8 +68,7 @@ pub fn run_spec_test(script: SpecTestScript) -> Result<()> {
             Cmd::Module(m) => match m {
                 Module::Module(m) =>  {
                     println!("NORMAL MODULE");
-                    let compiled = compile(m);
-                    module = Some(runtime.load(compiled)?);
+                    module = Some(runtime.load_ast(m)?);
                 },
                 Module::Binary(_) => println!("BINARY MODULE ACTION"),
                 Module::Quote(_) => println!("QUOTE MODULE ACTION"),


### PR DESCRIPTION
This will replace the old module package pseudo-syntax that was used to
bootstrap the binary parser.