### PR TITLE
Split table field parse result to contain elems as individual field

### DIFF
--- a/src/format/binary/section.rs
+++ b/src/format/binary/section.rs
@@ -92,7 +92,7 @@ pub enum Section {
     Types(Vec<syntax::TypeField>),
     Imports(Vec<syntax::ImportField<syntax::Resolved>>),
     Funcs(Vec<syntax::Index<syntax::Resolved, syntax::TypeIndex>>),
-    Tables(Vec<syntax::TableField<syntax::Resolved>>),
+    Tables(Vec<syntax::TableField>),
     Mems(Vec<syntax::MemoryField>),
     Globals(Vec<syntax::GlobalField<syntax::Resolved>>),
     Exports(Vec<syntax::ExportField<syntax::Resolved>>),

--- a/src/format/binary/tables.rs
+++ b/src/format/binary/tables.rs
@@ -1,7 +1,7 @@
 use super::values::ReadWasmValues;
 use crate::{
     error::{Result, ResultFrom},
-    syntax::{Resolved, TableField},
+    syntax::TableField,
 };
 
 /// Read the tables section of a binary module from a std::io::Read.
@@ -9,16 +9,15 @@ pub trait ReadTables: ReadWasmValues {
     /// Read a funcs section. This is just a vec(TypeIndex).
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.
-    fn read_tables_section(&mut self) -> Result<Vec<TableField<Resolved>>> {
+    fn read_tables_section(&mut self) -> Result<Vec<TableField>> {
         self.read_vec(|_, s| s.read_table_field().wrap("read table type"))
     }
 
-    fn read_table_field(&mut self) -> Result<TableField<Resolved>> {
+    fn read_table_field(&mut self) -> Result<TableField> {
         Ok(TableField {
             id: None,
             tabletype: self.read_table_type()?,
             exports: vec![],
-            elems: None,
         })
     }
 }

--- a/src/format/text/module_builder.rs
+++ b/src/format/text/module_builder.rs
@@ -136,7 +136,7 @@ impl ModuleBuilder {
         self.module.funcs.push(f);
     }
 
-    pub fn add_tablefield(&mut self, f: TableField<Unresolved>) {
+    pub fn add_tablefield(&mut self, f: TableField) {
         add_ident!(self, f, tableindices, tables, self.tableidx_offset);
 
         // export field may define new exports.
@@ -147,7 +147,6 @@ impl ModuleBuilder {
                 exportdesc: ExportDesc::Table(Index::unnamed(tableidx)),
             })
         }
-        // TODO elem contents may define new elem
         self.module.tables.push(f);
     }
 

--- a/src/format/text/resolve.rs
+++ b/src/format/text/resolve.rs
@@ -6,7 +6,7 @@ use crate::syntax::{
     DataField, DataIndex, DataInit, ElemField, ElemIndex, ElemList, ExportDesc, ExportField, Expr,
     FuncField, FuncIndex, GlobalField, GlobalIndex, ImportDesc, ImportField, Index, Instruction,
     LabelIndex, LocalIndex, MemoryIndex, ModeEntry, Module, Operands, Resolved, StartField,
-    TableElems, TableField, TableIndex, TablePosition, TableUse, TypeIndex, TypeUse, Unresolved,
+    TableElems, TableIndex, TablePosition, TableUse, TypeIndex, TypeUse, Unresolved,
 };
 
 #[derive(Debug)]
@@ -163,18 +163,6 @@ impl Resolve<Operands<Resolved>> for Operands<Unresolved> {
     }
 }
 
-impl Resolve<TableField<Resolved>> for TableField<Unresolved> {
-    fn resolve(self, ic: &IdentifierContext) -> Result<TableField<Resolved>> {
-        resolve_option!(elems, self.elems, ic);
-        Ok(TableField {
-            id: self.id,
-            exports: self.exports,
-            tabletype: self.tabletype,
-            elems,
-        })
-    }
-}
-
 impl Resolve<TableElems<Resolved>> for TableElems<Unresolved> {
     fn resolve(self, ic: &IdentifierContext) -> Result<TableElems<Resolved>> {
         Ok(match self {
@@ -318,7 +306,6 @@ impl Resolve<DataInit<Resolved>> for DataInit<Unresolved> {
 impl Resolve<Module<Resolved>> for Module<Unresolved> {
     fn resolve(self, ic: &IdentifierContext) -> Result<Module<Resolved>> {
         resolve_all!(funcs, self.funcs, ic);
-        resolve_all!(tables, self.tables, ic);
         resolve_all!(imports, self.imports, ic);
         resolve_all!(exports, self.exports, ic);
         resolve_all!(globals, self.globals, ic);
@@ -329,7 +316,7 @@ impl Resolve<Module<Resolved>> for Module<Unresolved> {
             id: self.id,
             types: self.types,
             funcs: funcs?,
-            tables: tables?,
+            tables: self.tables,
             memories: self.memories,
             imports: imports?,
             exports: exports?,

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -81,7 +81,7 @@ pub struct Module<R: ResolvedState> {
     pub id: Option<String>,
     pub types: Vec<TypeField>,
     pub funcs: Vec<FuncField<R>>,
-    pub tables: Vec<TableField<R>>,
+    pub tables: Vec<TableField>,
     pub memories: Vec<MemoryField>,
     pub imports: Vec<ImportField<R>>,
     pub exports: Vec<ExportField<R>>,
@@ -120,20 +120,6 @@ impl<I: ResolvedState> fmt::Debug for Module<I> {
         write!(f, "\n)")?;
         write!(f, ".IdentifierContext:")
     }
-}
-
-#[derive(Debug, PartialEq)]
-pub enum Field<R: ResolvedState> {
-    Type(TypeField),
-    Func(FuncField<R>),
-    Table(TableField<R>),
-    Memory(MemoryField),
-    Import(ImportField<R>),
-    Export(ExportField<R>),
-    Global(GlobalField<R>),
-    Start(StartField<R>),
-    Elem(ElemField<R>),
-    Data(DataField<R>),
 }
 
 #[derive(PartialEq, Clone, Default)]
@@ -323,11 +309,10 @@ pub enum TableElems<R: ResolvedState> {
 // Abbreviations:
 // inline imports/exports
 // inline elem
-pub struct TableField<R: ResolvedState> {
+pub struct TableField {
     pub id: Option<String>,
     pub exports: Vec<String>,
     pub tabletype: TableType,
-    pub elems: Option<TableElems<R>>,
 }
 
 // memory := (memory id? <memtype>)


### PR DESCRIPTION
This simplifies the structure, and more closely matches the description
in the spec.