### PR TITLE
More work to get all spec tests at least parsing & compiling

### DIFF
--- a/codegen/master_ops_list.csv
+++ b/codegen/master_ops_list.csv
@@ -117,8 +117,6 @@
 
 0x25      ,table.get                     ,(TableIndex)
 0x26      ,table.set                     ,(TableIndex)
-| panic!("table.set")
-
 0x28      ,i32.load                      ,(Memargs)
 | let v = _ec.get_mem_i32()?;
 | _ec.push(v)

--- a/codegen/master_secondary_ops_list.csv
+++ b/codegen/master_secondary_ops_list.csv
@@ -19,4 +19,9 @@
 0x0e      ,table.copy                    ,(TableCopy)
 0x0f      ,table.grow                    ,(TableIndex)
 0x10      ,table.size                    ,(TableIndex)
+| // TODO
+| let _ti = _ec.op_u32()?;
+| _ec.push_value(0.into())?;
+| Ok(())
+
 0x11      ,table.fill                    ,(TableIndex)

--- a/codegen/src/code.rs
+++ b/codegen/src/code.rs
@@ -4,7 +4,7 @@ use std::io::{Result, Write};
 
 /// Emit the execution functions for all of the [Instructions][Instruction] in the provided set.
 pub trait EmitCode: Write + std::fmt::Debug {
-    fn emit_code_file(&mut self, insts: &HashMap<u32, Instruction>) -> Result<()> {
+    fn emit_code_file(&mut self, insts: &HashMap<u8, Instruction>) -> Result<()> {
         self.write_all(CODE_HEADER.as_bytes())?;
 
         for (_, inst) in insts.iter() {

--- a/codegen/src/data_table.rs
+++ b/codegen/src/data_table.rs
@@ -15,10 +15,10 @@ pub static INSTRUCTION_DATA: &[&InstructionData] = &[
 pub trait EmitDataTable: Write {
     /// Emit the code for the table of [InstructionData][wrausmt::instruction::InstructionData]
     /// items, in opcode order.
-    fn emit_instruction_data_table(&mut self, insts: &HashMap<u32, Instruction>) -> Result<()> {
+    fn emit_instruction_data_table(&mut self, insts: &HashMap<u8, Instruction>) -> Result<()> {
         self.write_all(DATA_TABLE_HEADER.as_bytes())?;
 
-        for i in 0u32..256 {
+        for i in 0u8..=255 {
             self.write_all(data_table_item(insts.get(&i)).as_bytes())?;
         }
 
@@ -36,7 +36,7 @@ fn data_table_item(inst: Option<&Instruction>) -> String {
     match inst {
         Some(i) => format!(
             "    &InstructionData {{
-        opcode: {},
+        opcode: {:#x},
         name: \"{}\",
         operands: {},
     }},\n",

--- a/codegen/src/exec_table.rs
+++ b/codegen/src/exec_table.rs
@@ -6,10 +6,10 @@ use std::io::{Result, Write};
 pub trait EmitExecTable: Write + std::fmt::Debug {
     /// Emit the file containing the lookup table array. It generates an array with 256 entries,
     /// and each entry in the array corresponds to one opcode.
-    fn emit_exec_table(&mut self, insts: &HashMap<u32, Instruction>) -> Result<()> {
+    fn emit_exec_table(&mut self, insts: &HashMap<u8, Instruction>) -> Result<()> {
         self.write_all(EXEC_TABLE_HEADER.as_bytes())?;
 
-        for i in 0u32..256 {
+        for i in 0u8..=255 {
             self.write_all(exec_table_item(insts.get(&i)).as_bytes())?;
         }
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -22,7 +22,7 @@ pub struct Instruction {
     name: String,
 
     /// The opcdoe of the instruction, as a hex number starting with 0x.
-    opcode: String,
+    opcode: u8,
 
     /// The operands descriptor.
     operands: String,
@@ -38,14 +38,14 @@ impl Instruction {
         Instruction {
             typename: fields::typename(fields[1]),
             name: fields[1].to_string(),
-            opcode: fields[0].to_string(),
+            opcode: fields::hex(fields[0]) as u8,
             operands: fields::operands(fields[2]),
             body: String::new(),
         }
     }
 }
 
-fn read_instruction_list(file: &str) -> io::Result<HashMap<u32, Instruction>> {
+fn read_instruction_list(file: &str) -> io::Result<HashMap<u8, Instruction>> {
     let f = fs::File::open(file)?;
     let buf_reader = io::BufReader::new(f);
 
@@ -92,9 +92,7 @@ fn read_instruction_list(file: &str) -> io::Result<HashMap<u32, Instruction>> {
         // If we were actually collecting an instruction (this wasn't the first one)
         // add it to the instructions lists.
         if !oldinst.typename.is_empty() {
-            let opcode = fields::hex(&oldinst.opcode);
-            println!("OPCDOE FOR {} IS {}", oldinst.opcode, opcode);
-            insts.insert(opcode, oldinst);
+            insts.insert(oldinst.opcode, oldinst);
         }
     }
 
@@ -109,7 +107,8 @@ pub fn parse() -> io::Result<()> {
 
     // There's plenty of room in the primary opcode space, so we put secondary instructions in
     // there starting at 0xE0
-    for (k, v) in secondary_instructions.into_iter() {
+    for (k, mut v) in secondary_instructions.into_iter() {
+        v.opcode += 0xE0;
         insts.insert(k + 0xE0, v);
     }
 

--- a/src/format/text/lex/num.rs
+++ b/src/format/text/lex/num.rs
@@ -29,7 +29,7 @@ pub fn maybe_number(idchars: &str) -> Option<Token> {
 
     // Hack until hexfloats are implemented
     // To get some spec tests passing.
-    if numchars == "0x0p+0" {
+    if matches!(numchars, "0x0p+0" | "-0x0p+0") {
         return Some(Token::Float(0.0));
     }
 

--- a/src/format/text/parse/mod.rs
+++ b/src/format/text/parse/mod.rs
@@ -71,10 +71,12 @@ impl<R: Read> Parser<R> {
         while self.next.token.ignorable() {
             self.next()?;
         }
+        /*
         println!(
             "TOKENS ARE NOW {:?} {:?}",
             self.current.token, self.next.token
         );
+        */
         Ok(out)
     }
 

--- a/src/format/text/parse/table.rs
+++ b/src/format/text/parse/table.rs
@@ -122,7 +122,7 @@ impl<R: Read> Parser<R> {
     // elemexpr := ('item' <expr>)
     //           | <instr>
     //           | func <index>*
-    fn try_elemlist(&mut self) -> Result<ElemList<Unresolved>> {
+    fn try_elemlist(&mut self, allow_bare_funcidx: bool) -> Result<ElemList<Unresolved>> {
         let _reftype = self.try_reftype()?;
         let items = self.zero_or_more(Self::try_elem_item)?;
         if !items.is_empty() {
@@ -130,7 +130,7 @@ impl<R: Read> Parser<R> {
         }
         // TODO single instruction
 
-        if self.take_keyword_if(|kw| kw == "func")?.is_some() {
+        if self.take_keyword_if(|kw| kw == "func")?.is_some() || allow_bare_funcidx {
             let items = self.zero_or_more(Self::try_index_as_funcref)?;
             return Ok(ElemList::func(items));
         }
@@ -157,7 +157,7 @@ impl<R: Read> Parser<R> {
 
         let offset = self.try_elem_offset()?;
 
-        let elemlist = self.try_elemlist()?;
+        let elemlist = self.try_elemlist(tableuse.is_none())?;
 
         let mode = if declarative.is_some() {
             ModeEntry::Declarative

--- a/src/format/text/parse/valtype.rs
+++ b/src/format/text/parse/valtype.rs
@@ -13,8 +13,8 @@ impl<R: Read> Parser<R> {
     pub fn try_valtype(&mut self) -> Result<Option<ValueType>> {
         let result = match &self.current.token {
             Token::Keyword(kw) => match kw.as_str() {
-                "func" | "funcref" => Some(ValueType::Ref(RefType::Func)),
-                "extern" | "externref" => Some(ValueType::Ref(RefType::Extern)),
+                "funcref" => Some(ValueType::Ref(RefType::Func)),
+                "externref" => Some(ValueType::Ref(RefType::Extern)),
                 "i32" => Some(ValueType::Num(NumType::I32)),
                 "i64" => Some(ValueType::Num(NumType::I64)),
                 "f32" => Some(ValueType::Num(NumType::F32)),
@@ -37,8 +37,8 @@ impl<R: Read> Parser<R> {
     pub fn try_reftype(&mut self) -> Result<Option<RefType>> {
         let result = match &self.current.token {
             Token::Keyword(kw) => match kw.as_str() {
-                "func" | "funcref" => Some(RefType::Func),
-                "extern" | "externref" => Some(RefType::Extern),
+                "funcref" => Some(RefType::Func),
+                "externref" => Some(RefType::Extern),
                 _ => None,
             },
             _ => None,
@@ -47,5 +47,25 @@ impl<R: Read> Parser<R> {
             self.advance()?;
         }
         Ok(result)
+    }
+
+    pub fn try_heaptype(&mut self) -> Result<Option<RefType>> {
+        let result = match &self.current.token {
+            Token::Keyword(kw) => match kw.as_str() {
+                "func" => Some(RefType::Func),
+                "extern" => Some(RefType::Extern),
+                _ => None,
+            },
+            _ => None,
+        };
+        if result.is_some() {
+            self.advance()?;
+        }
+        Ok(result)
+    }
+
+    pub fn expect_heaptype(&mut self) -> Result<RefType> {
+        self.try_heaptype()?
+            .ok_or_else(|| ParseError::unexpected("heaptype"))
     }
 }

--- a/src/format/text/resolve.rs
+++ b/src/format/text/resolve.rs
@@ -145,7 +145,6 @@ impl Resolve<Operands<Resolved>> for Operands<Unresolved> {
                     _ => "".into(),
                 };
                 let bic = ic.with_label(lid);
-                println!("RESOLVING BLOCK WITH {:#?}", bic);
                 Operands::Block(id, typ.resolve(&bic)?, expr.resolve(&bic)?, cnt)
             }
             Operands::FuncIndex(idx) => Operands::FuncIndex(idx.resolve(&ic)?),
@@ -157,6 +156,9 @@ impl Resolve<Operands<Resolved>> for Operands<Unresolved> {
             Operands::LabelIndex(idx) => Operands::LabelIndex(idx.resolve(&ic)?),
             Operands::TableInit(tidx, eidx) => {
                 Operands::TableInit(tidx.resolve(&ic)?, eidx.resolve(&ic)?)
+            }
+            Operands::TableCopy(tidx, t2idx) => {
+                Operands::TableCopy(tidx.resolve(&ic)?, t2idx.resolve(&ic)?)
             }
             Operands::Memargs(a, o) => Operands::Memargs(a, o),
             Operands::HeapType(r) => Operands::HeapType(r),

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -15,7 +15,7 @@ pub struct PrintLogger {
 impl Default for PrintLogger {
     fn default() -> Self {
         let mut tags = HashSet::default();
-        tags.insert("ENTER".to_owned());
+        tags.insert("SPEC".to_owned());
         Self { tags }
     }
 }

--- a/src/runtime/compile.rs
+++ b/src/runtime/compile.rs
@@ -155,6 +155,10 @@ pub trait Emitter {
                     self.emit32(ti.value());
                     self.emit32(ei.value());
                 }
+                syntax::Operands::TableCopy(ti, t2i) => {
+                    self.emit32(ti.value());
+                    self.emit32(t2i.value());
+                }
                 syntax::Operands::HeapType(_) => (),
             }
         }

--- a/src/runtime/instance/mem_instance.rs
+++ b/src/runtime/instance/mem_instance.rs
@@ -29,23 +29,19 @@ impl MemInstance {
     ///
     /// [Spec]: https://webassembly.github.io/spec/core/exec/runtime.html#memory-instances
     pub fn new(memtype: MemType) -> MemInstance {
-        println!("INIT MEM {:?}", memtype.limits);
         let data = vec![0u8; memtype.limits.lower as usize * PAGE_SIZE];
         MemInstance { memtype, data }
     }
 
     pub fn new_ast(memfield: MemoryField) -> MemInstance {
         let memtype = memfield.memtype;
-        println!("INIT MEM {:?}", memtype.limits);
         let data = vec![0u8; memtype.limits.lower as usize * PAGE_SIZE];
         MemInstance { memtype, data }
     }
 
     pub fn grow(&mut self, pgs: u32) -> Option<u32> {
-        println!("CURRENT MEM SIZE {}", self.data.len());
         if let Some(upper) = self.memtype.limits.upper {
             if pgs * PAGE_SIZE as u32 > upper {
-                println!("CAN'T GROW");
                 return None;
             }
         }
@@ -53,7 +49,6 @@ impl MemInstance {
         let newsize = self.data.len() + (pgs as usize * PAGE_SIZE);
         let old_size_in_pages = self.data.len() / PAGE_SIZE;
 
-        println!("GREW TO {}", newsize);
         self.data.resize(newsize, 0);
 
         Some(old_size_in_pages as u32)

--- a/src/spec/format/mod.rs
+++ b/src/spec/format/mod.rs
@@ -73,7 +73,13 @@ impl<R: Read> Parser<R> {
             return Ok(None);
         }
 
-        Ok(None)
+        let modname = self.expect_string()?;
+
+        let id = self.try_id()?;
+
+        self.expect_close()?;
+
+        Ok(Some(Cmd::Register { modname, id }))
     }
 
     fn try_action_cmd(&mut self) -> Result<Option<Cmd>> {
@@ -245,7 +251,7 @@ impl<R: Read> Parser<R> {
 
     fn try_result(&mut self) -> Result<Option<ActionResult>> {
         if self.try_expr_start("ref.null")? {
-            let _reftype = self.expect_reftype()?;
+            let _reftype = self.expect_heaptype()?;
             self.expect_close()?;
             return Ok(Some(ActionResult::Func));
         }
@@ -271,7 +277,7 @@ impl<R: Read> Parser<R> {
 
     fn try_const(&mut self) -> Result<Option<Const>> {
         if self.try_expr_start("ref.null")? {
-            let reftype = self.expect_reftype()?;
+            let reftype = self.expect_heaptype()?;
             self.expect_close()?;
             return Ok(Some(Const::RefNull(reftype)));
         }
@@ -340,7 +346,7 @@ pub struct SpecTestScript {
 #[derive(Debug)]
 pub enum Cmd {
     Module(Module),
-    Register { string: String, name: String },
+    Register { modname: String, id: Option<String> },
     Action(Action),
     Assertion(Assertion),
     Meta(Meta),

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -65,6 +65,15 @@ impl<R: ResolvedState, S: IndexSpace> Index<R, S> {
             indexmarker: PhantomData {},
         }
     }
+
+    pub fn convert<S2: IndexSpace>(self) -> Index<R, S2> {
+        Index {
+            name: self.name,
+            value: self.value,
+            resolvedmarker: PhantomData {},
+            indexmarker: PhantomData {},
+        }
+    }
 }
 
 impl<R: ResolvedState, S: IndexSpace> fmt::Debug for Index<R, S> {
@@ -467,6 +476,7 @@ pub enum Operands<R: ResolvedState> {
     Memargs(u32, u32),
     HeapType(RefType),
     TableInit(Index<R, TableIndex>, Index<R, ElemIndex>),
+    TableCopy(Index<R, TableIndex>, Index<R, TableIndex>),
     I32(u32),
     I64(u64),
     F32(f32),

--- a/tests/spec_runner.rs
+++ b/tests/spec_runner.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
-use wrausmt::format::text::parse::Parser;
 use wrausmt::spec::runner::run_spec_test;
 use wrausmt::{format::text::lex::Tokenizer, spec::runner::RunSet};
+use wrausmt::{format::text::parse::Parser, runset_specific};
 
 use wrausmt::runset_exclude;
 
@@ -45,14 +45,17 @@ fn spec_tests() -> Result<()> {
     Ok(())
 }
 
-#[allow(dead_code)]
-fn spec_tests_all() -> Result<()> {
+#[test]
+fn spec_tests_all_run_ignore_failure() -> Result<()> {
     for entry in std::fs::read_dir("testdata/spec")? {
         let entry = entry?;
         let path = entry.path();
         if path.is_file() {
+            println!("RUNNING {:?}", path);
             match parse_and_run(&path, RunSet::All) {
-                Ok(()) => (),
+                Ok(()) => {
+                    println!("Tests succeeded {:?}", path);
+                }
                 Err(e) => {
                     println!("{:?} During {:?}", e, path);
                 }
@@ -96,4 +99,9 @@ fn callexclude() -> Result<()> {
         "testdata/spec/call.wast",
         runset_exclude!("as-load-operand", "as-unary-operand", "as-convert-operand"),
     )
+}
+
+#[test]
+fn callspecific() -> Result<()> {
+    parse_and_run("testdata/spec/call.wast", runset_specific!("odd"))
 }


### PR DESCRIPTION
* Handle the Memory* operands types in text parser
* Add support for TableInit/TableCopy instructions
* Fix ref.null parsing (heaptype, not reftype)
* Add parsing of memory & data module fields
* Fix handling of bare function idx list in elem list
* Set a max stack depth of 256
* Parse register cmds in spec tests properly
* Fix instruction data opcode for secondary instructions