### PR TITLE
Store potentially non-UTF8 bytes in wasm string token

### DIFF
--- a/src/format/text/lex/error.rs
+++ b/src/format/text/lex/error.rs
@@ -4,6 +4,7 @@ pub enum LexError {
     IoError(std::io::Error),
     Utf8Error(std::string::FromUtf8Error),
     UnexpectedChar(char),
+    InvalidEscape(u8),
 }
 
 pub type Result<T> = std::result::Result<T, LexError>;

--- a/src/format/text/lex/mod.rs
+++ b/src/format/text/lex/mod.rs
@@ -1,7 +1,7 @@
 use self::error::LexError;
 
 use super::token::{FileToken, Token};
-use crate::format::Location;
+use crate::format::{text::string::WasmString, Location};
 mod chars;
 pub mod error;
 mod num;
@@ -154,9 +154,9 @@ impl<R: Read> Tokenizer<R> {
         loop {
             self.advance()?;
             if self.current == b'"' && prev != b'\\' {
-                let as_string = String::from_utf8(result).ctx("consuming string literal")?;
                 self.advance()?;
-                return Ok(Token::String(as_string));
+                let ws = WasmString::from_bytes(&result)?;
+                return Ok(Token::String(ws));
             }
             result.push(self.current);
             prev = self.current;

--- a/src/format/text/lex/test.rs
+++ b/src/format/text/lex/test.rs
@@ -1,6 +1,9 @@
 use super::super::token::{FileToken, Sign, Token};
 use super::Tokenizer;
-use crate::format::text::lex::error::{Result, WithContext};
+use crate::format::text::{
+    lex::error::{Result, WithContext},
+    string::WasmString,
+};
 
 macro_rules! expect_tokens {
     ( $to_parse:expr, $($t:expr),* ) => {
@@ -25,7 +28,7 @@ fn simple_parse() -> Result<()> {
         Token::Keyword("foo".into()),
         Token::Close,
         Token::Whitespace,
-        Token::String("hello".into()),
+        Token::String(WasmString::from_bytes("hello".as_bytes()).unwrap()),
         Token::Whitespace,
         Token::Open,
         Token::Float(5.6),
@@ -46,9 +49,20 @@ fn simple_parse() -> Result<()> {
 
 #[test]
 fn bare_string() -> Result<()> {
+    let expect = "this is a 😃 string".as_bytes();
     expect_tokens!(
         "\"this is a 😃 string\"",
-        Token::String("this is a 😃 string".into())
+        Token::String(WasmString::from_bytes(expect).unwrap())
+    );
+    Ok(())
+}
+
+#[test]
+fn bytes_string() -> Result<()> {
+    let expect = b"this has raw data\x01\x02\xE4";
+    expect_tokens!(
+        "\"this has raw data\\01\\02\\E4\"",
+        Token::String(WasmString::from_bytes(expect).unwrap())
     );
     Ok(())
 }

--- a/src/format/text/mod.rs
+++ b/src/format/text/mod.rs
@@ -5,3 +5,4 @@ pub mod macros;
 pub mod module_builder;
 pub mod parse;
 pub mod resolve;
+pub mod string;

--- a/src/format/text/parse/error.rs
+++ b/src/format/text/parse/error.rs
@@ -1,3 +1,5 @@
+use std::string::FromUtf8Error;
+
 use crate::format::text::{lex::error::LexError, resolve::ResolveError, token::FileToken};
 
 #[derive(Debug)]
@@ -15,6 +17,7 @@ pub enum ParseError {
     UnexpectedToken(String),
     UnrecognizedInstruction(String),
     ResolveError(ResolveError),
+    Utf8Error(FromUtf8Error),
     Incomplete,
 }
 
@@ -37,5 +40,11 @@ pub type Result<T> = std::result::Result<T, ParseError>;
 impl From<ResolveError> for ParseError {
     fn from(re: ResolveError) -> Self {
         ParseError::ResolveError(re)
+    }
+}
+
+impl From<FromUtf8Error> for ParseError {
+    fn from(e: FromUtf8Error) -> Self {
+        ParseError::Utf8Error(e)
     }
 }

--- a/src/format/text/parse/mod.rs
+++ b/src/format/text/parse/mod.rs
@@ -1,5 +1,5 @@
-use super::lex::Tokenizer;
 use super::token::{FileToken, Token};
+use super::{lex::Tokenizer, string::WasmString};
 use error::{ParseError, Result};
 use std::io::Read;
 
@@ -125,7 +125,7 @@ impl<R: Read> Parser<R> {
         }
     }
 
-    pub fn try_string(&mut self) -> Result<Option<String>> {
+    pub fn try_wasm_string(&mut self) -> Result<Option<WasmString>> {
         match self.current.token {
             Token::String(ref mut data) => {
                 let data = std::mem::take(data);
@@ -134,6 +134,14 @@ impl<R: Read> Parser<R> {
             }
             _ => Ok(None),
         }
+    }
+
+    pub fn try_string(&mut self) -> Result<Option<String>> {
+        let result = self.try_wasm_string()?;
+        Ok(match result {
+            Some(ws) => Some(ws.into_string()?),
+            None => None,
+        })
     }
 
     pub fn expect_string(&mut self) -> Result<String> {

--- a/src/format/text/string.rs
+++ b/src/format/text/string.rs
@@ -1,0 +1,66 @@
+use super::lex::error::{LexError, Result as LexResult};
+use std::string::FromUtf8Error;
+
+/// A WebAssembly text format string.
+/// They may contain any arbitrary bytes, not just valid UTF8.
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct WasmString {
+    bytes: Box<[u8]>,
+}
+
+fn parse_hex_digit(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+impl WasmString {
+    pub fn from_bytes(bytes: &[u8]) -> LexResult<WasmString> {
+        let mut result = Vec::with_capacity(bytes.len());
+        let mut i = 0;
+        while i < bytes.len() {
+            let b = bytes[i];
+            match b {
+                b'\\' => {
+                    i += 1;
+                    let next = bytes[i];
+                    let c = if let Some(d1) = parse_hex_digit(next) {
+                        i += 1;
+                        let next = bytes[i];
+                        if let Some(d2) = parse_hex_digit(next) {
+                            (d1 << 4) | d2
+                        } else {
+                            return Err(LexError::InvalidEscape(next));
+                        }
+                    } else {
+                        match next {
+                            b't' => b'\t',
+                            b'n' => b'\n',
+                            b'r' => b'\r',
+                            b'"' => b'\"',
+                            b'\'' => b'\'',
+                            b'\\' => b'\\',
+                            b'u' => {
+                                // TODO - unicode
+                                b'0'
+                            }
+                            _ => return Err(LexError::InvalidEscape(next)),
+                        }
+                    };
+                    result.push(c);
+                }
+                b => result.push(b),
+            }
+            i += 1;
+        }
+        Ok(WasmString {
+            bytes: result.into_boxed_slice(),
+        })
+    }
+
+    pub fn into_string(self) -> Result<String, FromUtf8Error> {
+        String::from_utf8(self.bytes.to_vec())
+    }
+}

--- a/src/format/text/token.rs
+++ b/src/format/text/token.rs
@@ -1,5 +1,7 @@
 use crate::format::Location;
 
+use super::string::WasmString;
+
 /// A [Token] along with context about its location in the source file.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct FileToken {
@@ -36,7 +38,7 @@ pub enum Token {
     Unsigned(u64),
     Signed(i64),
     Float(f64),
-    String(String),
+    String(WasmString),
     Id(String),
     Open,
     Close,

--- a/src/spec/format/mod.rs
+++ b/src/spec/format/mod.rs
@@ -1,5 +1,8 @@
 use crate::format::{
-    text::parse::error::{ParseError, Result},
+    text::{
+        parse::error::{ParseError, Result},
+        string::WasmString,
+    },
     Location,
 };
 use crate::syntax as modulesyntax;
@@ -58,12 +61,12 @@ impl<R: Read> Parser<R> {
 
         match kw.as_deref() {
             Some("binary") => {
-                let strings = self.zero_or_more(Self::try_string)?;
+                let strings = self.zero_or_more(Self::try_wasm_string)?;
                 self.expect_close()?;
                 Ok(Some(Module::Binary(strings)))
             }
             Some("quote") => {
-                let strings = self.zero_or_more(Self::try_string)?;
+                let strings = self.zero_or_more(Self::try_wasm_string)?;
                 self.expect_close()?;
                 Ok(Some(Module::Quote(strings)))
             }
@@ -389,8 +392,8 @@ pub struct CmdEntry {
 #[derive(Debug)]
 pub enum Module {
     Module(modulesyntax::Module<Resolved>),
-    Binary(Vec<String>),
-    Quote(Vec<String>),
+    Binary(Vec<WasmString>),
+    Quote(Vec<WasmString>),
 }
 
 /// action:


### PR DESCRIPTION
Handle parsing of \xx escape codes.