### PR TITLE
Properly track addresses in module instances

### DIFF
--- a/src/runtime/compile.rs
+++ b/src/runtime/compile.rs
@@ -25,10 +25,10 @@ impl From<syntax::Local> for ValueType {
 
 fn compile_export_desc(ast: syntax::ExportDesc<Resolved>, modinst: &ModuleInstance) -> ExternalVal {
     match ast {
-        syntax::ExportDesc::Func(idx) => ExternalVal::Func(idx.value() + modinst.func_offset),
-        syntax::ExportDesc::Table(idx) => ExternalVal::Table(idx.value() + modinst.table_offset),
-        syntax::ExportDesc::Mem(idx) => ExternalVal::Memory(idx.value() + modinst.mem_offset),
-        syntax::ExportDesc::Global(idx) => ExternalVal::Global(idx.value() + modinst.global_offset),
+        syntax::ExportDesc::Func(idx) => ExternalVal::Func(modinst.func(idx.value())),
+        syntax::ExportDesc::Table(idx) => ExternalVal::Table(modinst.table(idx.value())),
+        syntax::ExportDesc::Mem(idx) => ExternalVal::Memory(modinst.mem(idx.value())),
+        syntax::ExportDesc::Global(idx) => ExternalVal::Global(modinst.global(idx.value())),
     }
 }
 

--- a/src/runtime/exec.rs
+++ b/src/runtime/exec.rs
@@ -182,7 +182,7 @@ impl<'l> ExecutionContextActions for ExecutionContext<'l> {
         let dst = self.pop::<u32>()? as usize;
         // TODO if s + n or d + n > sie of table 0, trap
         let tableaddr = self.runtime.stack.get_table_addr(tableidx)?;
-        let elemaddr = self.runtime.stack.get_table_addr(elemidx)?;
+        let elemaddr = self.runtime.stack.get_elem_addr(elemidx)?;
         self.runtime
             .store
             .copy_elems_to_table(tableaddr, elemaddr, src, dst, n)

--- a/src/runtime/instance/module_instance.rs
+++ b/src/runtime/instance/module_instance.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::types::FunctionType;
+use crate::{runtime::store::addr, types::FunctionType};
 
 /// A module instance is the runtime representation of a module. [Spec][Spec]
 ///
@@ -18,38 +18,72 @@ use crate::types::FunctionType;
 /// [Spec]: https://webassembly.github.io/spec/core/exec/runtime.html#module-instances
 #[derive(Debug, Default, Clone)]
 pub struct ModuleInstance {
-    pub types: Box<[FunctionType]>,
-    pub exports: Box<[ExportInstance]>,
+    types: Box<[FunctionType]>,
+    exports: Box<[ExportInstance]>,
+    funcs: Box<[addr::FuncAddr]>,
+    tables: Box<[addr::TableAddr]>,
+    mems: Box<[addr::MemoryAddr]>,
+    globals: Box<[addr::GlobalAddr]>,
+    elems: Box<[addr::ElemAddr]>,
+    data: Box<[addr::DataAddr]>,
+}
 
-    pub func_offset: u32,
-    pub func_count: usize,
+#[derive(Debug, Default, Clone)]
+pub struct ModuleInstanceBuilder {
+    pub types: Vec<FunctionType>,
+    pub exports: Vec<ExportInstance>,
+    pub funcs: Vec<addr::FuncAddr>,
+    pub tables: Vec<addr::TableAddr>,
+    pub mems: Vec<addr::MemoryAddr>,
+    pub globals: Vec<addr::GlobalAddr>,
+    pub elems: Vec<addr::ElemAddr>,
+    pub data: Vec<addr::DataAddr>,
+}
 
-    pub table_offset: u32,
-    pub table_count: usize,
-
-    pub mem_offset: u32,
-    pub mem_count: usize,
-
-    pub elem_offset: u32,
-    pub elem_count: usize,
-
-    pub global_offset: u32,
-    pub global_count: usize,
+impl ModuleInstanceBuilder {
+    pub fn build(self) -> ModuleInstance {
+        ModuleInstance {
+            types: self.types.into_boxed_slice(),
+            exports: self.exports.into_boxed_slice(),
+            funcs: self.funcs.into_boxed_slice(),
+            tables: self.tables.into_boxed_slice(),
+            mems: self.mems.into_boxed_slice(),
+            globals: self.globals.into_boxed_slice(),
+            elems: self.elems.into_boxed_slice(),
+            data: self.data.into_boxed_slice(),
+        }
+    }
 }
 
 impl ModuleInstance {
+    pub fn func(&self, idx: u32) -> addr::FuncAddr {
+        self.funcs[idx as usize]
+    }
+
+    pub fn table(&self, idx: u32) -> addr::TableAddr {
+        self.tables[idx as usize]
+    }
+
+    pub fn mem(&self, idx: u32) -> addr::MemoryAddr {
+        self.mems[idx as usize]
+    }
+
+    pub fn global(&self, idx: u32) -> addr::GlobalAddr {
+        self.globals[idx as usize]
+    }
+
+    pub fn elem(&self, idx: u32) -> addr::ElemAddr {
+        println!("GET ELEM {} FROM {:?}", idx, self.elems);
+        self.elems[idx as usize]
+    }
+
+    pub fn data(&self, idx: u32) -> addr::DataAddr {
+        self.data[idx as usize]
+    }
+
     pub fn resolve(&self, name: &str) -> Option<&ExportInstance> {
         let found = self.exports.iter().find(|e| e.name == name);
 
         found
-    }
-
-    pub fn copy_for_init(&self) -> ModuleInstance {
-        ModuleInstance {
-            // TODO - globals and extern funcs
-            func_offset: self.func_offset,
-            func_count: self.func_count,
-            ..ModuleInstance::default()
-        }
     }
 }

--- a/src/runtime/stack.rs
+++ b/src/runtime/stack.rs
@@ -230,27 +230,29 @@ impl Stack {
 
     // Get the function address for the provided index in the current activation.
     pub fn get_function_addr(&self, idx: u32) -> Result<addr::FuncAddr> {
-        Ok(self.peek_activation()?.module.func_offset + idx)
+        Ok(self.peek_activation()?.module.func(idx))
     }
 
     // Get the function address for the provided index in the current activation.
     pub fn get_mem_addr(&self, idx: u32) -> Result<addr::FuncAddr> {
-        Ok(self.peek_activation()?.module.mem_offset + idx)
+        Ok(self.peek_activation()?.module.mem(idx))
     }
 
     // Get the global address for the provided index in the current activation.
     pub fn get_global_addr(&self, idx: u32) -> Result<addr::GlobalAddr> {
-        Ok(self.peek_activation()?.module.global_offset + idx)
+        Ok(self.peek_activation()?.module.global(idx))
     }
 
     // Get the function address for the provided index in the current activation.
     pub fn get_table_addr(&self, idx: u32) -> Result<addr::TableAddr> {
-        Ok(self.peek_activation()?.module.table_offset + idx)
+        println!("GET TABLE {}", idx);
+        Ok(self.peek_activation()?.module.table(idx))
     }
 
     // Get the function address for the provided index in the current activation.
     pub fn get_elem_addr(&self, idx: u32) -> Result<addr::ElemAddr> {
-        Ok(self.peek_activation()?.module.elem_offset + idx)
+        println!("GET ELEM {}", idx);
+        Ok(self.peek_activation()?.module.elem(idx))
     }
 
     pub fn get_label(&self, idx: u32) -> Result<&Label> {

--- a/src/runtime/store.rs
+++ b/src/runtime/store.rs
@@ -135,59 +135,59 @@ impl Store {
     // Allocate a collection of functions.
     // Functions will be allocated in a contiguous block.
     // Returns the value of the first allocated fuction.
-    pub fn alloc_funcs<I>(&mut self, funcs: I) -> (usize, addr::FuncAddr)
+    pub fn alloc_funcs<I>(&mut self, funcs: I) -> std::ops::Range<addr::FuncAddr>
     where
         I: Iterator<Item = Rc<FunctionInstance>>,
     {
-        let base_addr = self.funcs.len();
+        let base_addr = self.funcs.len() as u32;
         self.funcs.extend(funcs);
-        let count = self.funcs.len() - base_addr;
-        (count, base_addr as addr::FuncAddr)
+        let count = self.funcs.len() as u32 - base_addr;
+        base_addr..base_addr + count
     }
 
     // Allocate a collection of tables.
     // Tables will be allocated in a contiguous block.
     // Returns the value of the first allocated tables.
-    pub fn alloc_tables<I>(&mut self, tables: I) -> (usize, addr::TableAddr)
+    pub fn alloc_tables<I>(&mut self, tables: I) -> std::ops::Range<addr::TableAddr>
     where
         I: Iterator<Item = TableInstance>,
     {
-        let base_addr = self.tables.len();
+        let base_addr = self.tables.len() as u32;
         self.tables.extend(tables);
-        let count = self.tables.len() - base_addr;
-        (count, base_addr as addr::TableAddr)
+        let count = self.tables.len() as u32 - base_addr;
+        base_addr..base_addr + count
     }
 
     // Allocate a collection of mems.
     // Mems will be allocated in a contiguous block.
     // Returns the value of the first allocated mems.
-    pub fn alloc_mems<I>(&mut self, mems: I) -> (usize, addr::MemoryAddr)
+    pub fn alloc_mems<I>(&mut self, mems: I) -> std::ops::Range<addr::MemoryAddr>
     where
         I: Iterator<Item = MemInstance>,
     {
-        let base_addr = self.mems.len();
+        let base_addr = self.mems.len() as u32;
         self.mems.extend(mems);
-        let count = self.mems.len() - base_addr;
-        (count, base_addr as addr::MemoryAddr)
+        let count = self.mems.len() as u32 - base_addr;
+        base_addr..base_addr + count
     }
 
-    pub fn alloc_globals<I>(&mut self, globals: I) -> (usize, addr::GlobalAddr)
+    pub fn alloc_globals<I>(&mut self, globals: I) -> std::ops::Range<addr::GlobalAddr>
     where
         I: Iterator<Item = GlobalInstance>,
     {
-        let base_addr = self.globals.len();
+        let base_addr = self.globals.len() as u32;
         self.globals.extend(globals);
-        let count = self.globals.len() - base_addr;
-        (count, base_addr as addr::MemoryAddr)
+        let count = self.globals.len() as u32 - base_addr;
+        base_addr..base_addr + count
     }
 
-    pub fn alloc_elems<I>(&mut self, elems: I) -> (usize, addr::ElemAddr)
+    pub fn alloc_elems<I>(&mut self, elems: I) -> std::ops::Range<addr::ElemAddr>
     where
         I: Iterator<Item = ElemInstance>,
     {
-        let base_addr = self.elems.len();
+        let base_addr = self.elems.len() as u32;
         self.elems.extend(elems);
-        let count = self.elems.len() - base_addr;
-        (count, base_addr as addr::ElemAddr)
+        let count = self.elems.len() as u32 - base_addr;
+        base_addr..base_addr + count
     }
 }


### PR DESCRIPTION
To set up proper handling of imports, track function, table, global, and
mem addresses using an actual array, rather than just a count and
offset, since imports will need to go at the front of this array.