### PR TITLE
Remove usage of RefCell in favor of small unsafe usage

### DIFF
--- a/src/runtime/instance/function_instance.rs
+++ b/src/runtime/instance/function_instance.rs
@@ -1,4 +1,3 @@
-use crate::error;
 use crate::runtime::error::ArgumentCountError;
 use crate::runtime::instance::ModuleInstance;
 use crate::runtime::Value;
@@ -8,7 +7,6 @@ use crate::{
     instructions::Expr,
     types::ValueType,
 };
-use std::cell::RefCell;
 use std::rc::Rc;
 
 /// A function instance is the runtime representation of a function. [Spec][Spec]
@@ -21,7 +19,7 @@ use std::rc::Rc;
 #[derive(Debug)]
 pub struct FunctionInstance {
     pub functype: FunctionType,
-    pub module_instance: RefCell<Option<Rc<ModuleInstance>>>,
+    pub module_instance: Rc<ModuleInstance>,
 
     /// The locals declare a vector of mutable local variables and their types. These variables are
     /// referenced through local indices in the function's body. The index of the first local is
@@ -56,10 +54,7 @@ impl FunctionInstance {
         Ok(())
     }
 
-    pub fn module_instance(&self) -> Result<Rc<ModuleInstance>> {
-        self.module_instance
-            .borrow()
-            .clone()
-            .ok_or_else(|| error!("no module instance on function"))
+    pub fn module_instance(&self) -> Rc<ModuleInstance> {
+        self.module_instance.clone()
     }
 }

--- a/src/runtime/stack.rs
+++ b/src/runtime/stack.rs
@@ -112,7 +112,7 @@ impl Stack {
         self.activation_stack.push(ActivationFrame {
             arity,
             local_start: frame_start,
-            module: funcinst.module_instance()?,
+            module: funcinst.module_instance(),
             label_stack: vec![],
         });
         self.logger.log("ACTIVATE", || {


### PR DESCRIPTION
Since the ModuleInstance for functions only needs to be updated a few
times during initialization, do it using an unsafe pointer access. This
removes the need for a RefCell wrapper, and should not cause any other
problems.