### PR TITLE
Clean up the memory get/set code

### DIFF
--- a/codegen/master_ops_list.csv
+++ b/codegen/master_ops_list.csv
@@ -118,87 +118,119 @@
 0x25      ,table.get                     ,(TableIndex)
 0x26      ,table.set                     ,(TableIndex)
 0x28      ,i32.load                      ,(Memargs)
-| let v = _ec.get_mem_i32()?;
+| let bs = _ec.get_mem::<4>()?;
+| let v = u32::from_le_bytes(bs);
 | _ec.push(v)
 
 0x29      ,i64.load                      ,(Memargs)
-| let v = _ec.get_mem_i64()?;
+| let bs = _ec.get_mem::<8>()?;
+| let v = u64::from_le_bytes(bs);
 | _ec.push(v)
 
 0x2a      ,f32.load                      ,(Memargs)
-| let v = _ec.get_mem_f32()?;
+| let bs = _ec.get_mem::<4>()?;
+| let v = f32::from_le_bytes(bs);
 | _ec.push(v)
 
 0x2b      ,f64.load                      ,(Memargs)
-| let v = _ec.get_mem_f64()?;
+| let bs = _ec.get_mem::<8>()?;
+| let v = f64::from_le_bytes(bs);
 | _ec.push(v)
 
 0x2c      ,i32.load8_s                   ,(Memargs)
-| let v = _ec.get_mem_i32_8s()?;
+| let bs = _ec.get_mem::<1>()?;
+| let v = i8::from_le_bytes(bs);
 | _ec.push(v as i32)
 
 0x2d      ,i32.load8_u                   ,(Memargs)
-| let v = _ec.get_mem_i32_8u()?;
+| let bs = _ec.get_mem::<1>()?;
+| let v = u8::from_le_bytes(bs);
 | _ec.push(v as u32)
 
 0x2e      ,i32.load16_s                  ,(Memargs)
-| let v = _ec.get_mem_i32_16s()?;
+| let bs = _ec.get_mem::<2>()?;
+| let v = i16::from_le_bytes(bs);
 | _ec.push(v as i32)
 
 0x2f      ,i32.load16_u                  ,(Memargs)
-| let v = _ec.get_mem_i32_16u()?;
+| let bs = _ec.get_mem::<2>()?;
+| let v = u16::from_le_bytes(bs);
 | _ec.push(v as u32)
 
 0x30      ,i64.load8_s                   ,(Memargs)
-| let v = _ec.get_mem_i64_8s()?;
+| let bs = _ec.get_mem::<1>()?;
+| let v = i8::from_le_bytes(bs);
 | _ec.push(v as i64)
 
 0x31      ,i64.load8_u                   ,(Memargs)
-| let v = _ec.get_mem_i64_8u()?;
+| let bs = _ec.get_mem::<1>()?;
+| let v = u8::from_le_bytes(bs);
 | _ec.push(v as i64)
 
 0x32      ,i64.load16_s                  ,(Memargs)
-| let v = _ec.get_mem_i64_16s()?;
+| let bs = _ec.get_mem::<2>()?;
+| let v = i16::from_le_bytes(bs);
 | _ec.push(v as i64)
 
 0x33      ,i64.load16_u                  ,(Memargs)
-| let v = _ec.get_mem_i64_16u()?;
-| _ec.push(v as i64)
+| let bs = _ec.get_mem::<2>()?;
+| let v = u16::from_le_bytes(bs);
+| _ec.push(v as u64)
 
 0x34      ,i64.load32_s                  ,(Memargs)
-| let v = _ec.get_mem_i64_32s()?;
+| let bs = _ec.get_mem::<4>()?;
+| let v = i32::from_le_bytes(bs);
 | _ec.push(v as i64)
 
 0x35      ,i64.load32_u                  ,(Memargs)
-| let v = _ec.get_mem_i64_32u()?;
-| _ec.push(v as i64)
+| let bs = _ec.get_mem::<4>()?;
+| let v = u32::from_le_bytes(bs);
+| _ec.push(v as u64)
 
 0x36      ,i32.store                     ,(Memargs)
-| _ec.set_mem_i32()
+| let v = _ec.pop::<u32>()?;
+| let bs = v.to_le_bytes();
+| _ec.put_mem::<4>(bs)
 
 0x37      ,i64.store                     ,(Memargs)
-| _ec.set_mem_i64()
+| let v = _ec.pop::<u64>()?;
+| let bs = v.to_le_bytes();
+| _ec.put_mem::<8>(bs)
 
 0x38      ,f32.store                     ,(Memargs)
-| _ec.set_mem_f32()
+| let v = _ec.pop::<f32>()?;
+| let bs = v.to_le_bytes();
+| _ec.put_mem::<4>(bs)
 
 0x39      ,f64.store                     ,(Memargs)
-| _ec.set_mem_f64()
+| let v = _ec.pop::<f64>()?;
+| let bs = v.to_le_bytes();
+| _ec.put_mem::<8>(bs)
 
 0x3a      ,i32.store8                    ,(Memargs)
-| _ec.set_mem_i32_8()
+| let v = _ec.pop::<u32>()? as u8;
+| let bs = v.to_le_bytes();
+| _ec.put_mem::<1>(bs)
 
 0x3b      ,i32.store16                   ,(Memargs)
-| _ec.set_mem_i32_16()
+| let v = _ec.pop::<u32>()? as u16;
+| let bs = v.to_le_bytes();
+| _ec.put_mem::<2>(bs)
 
 0x3c      ,i64.store8                    ,(Memargs)
-| _ec.set_mem_i64_8()
+| let v = _ec.pop::<u64>()? as u8;
+| let bs = v.to_le_bytes();
+| _ec.put_mem::<1>(bs)
 
 0x3D      ,i64.store16                   ,(Memargs)
-| _ec.set_mem_i64_16()
+| let v = _ec.pop::<u64>()? as u16;
+| let bs = v.to_le_bytes();
+| _ec.put_mem::<2>(bs)
 
 0x3E      ,i64.store32                   ,(Memargs)
-| _ec.set_mem_i64_32()
+| let v = _ec.pop::<u64>()? as u32;
+| let bs = v.to_le_bytes();
+| _ec.put_mem::<4>(bs)
 
 0x3f      ,memory.size                   ,(MemorySize)
 0x40      ,memory.grow                   ,(MemoryGrow)

--- a/src/runtime/exec.rs
+++ b/src/runtime/exec.rs
@@ -15,48 +15,6 @@ pub struct ExecutionContext<'l> {
     pc: usize,
 }
 
-/// Emit an implementation for one of the memory load instructions.
-/// $n - the name of the function to emit
-/// $t - the return type of the functiona
-/// $s - the type of the stored value
-macro_rules! get_mem {
-    ( $n:ident, $t:ty, $s:expr ) => {
-        fn $n(&mut self) -> Result<$t> {
-            let _a = self.op_u32()?;
-            let o = self.op_u32()?;
-            let b = self.pop::<u32>()?;
-            let i = (b + o) as usize;
-            let db: [u8; $s] = self.mem(0)?.data[i..i + $s].try_into().wrap("to array")?;
-            self.log("MEM", || {
-                format!("GET {} BYTES {:?} {}", $s, db, stringify!($t))
-            });
-            let val = <$t>::from_le_bytes(db);
-            Ok(val)
-        }
-    };
-}
-
-macro_rules! set_mem {
-    ( $n:ident, $t:ty, $st:ty, $s:expr ) => {
-        fn $n(&mut self) -> Result<()> {
-            let _a = self.op_u32()?;
-            let o = self.op_u32()?;
-            let val = self.pop::<$t>()? as $st;
-            let b = self.pop::<u32>()?;
-            let bs = val.to_le_bytes();
-            self.log("MEM", || format!("SETTING {:?} AS {:?}", val, bs));
-            let i = (o + b) as usize;
-            let m = self.mem(0)?;
-            if i + $s > m.data.len() {
-                // TODO better error -> trap
-                return err!("out of bounds {} {}", i, $s);
-            }
-            m.data[i..i + $s].clone_from_slice(&bs);
-            Ok(())
-        }
-    };
-}
-
 pub trait ExecutionContextActions {
     fn log<S: Borrow<str> + Eq + Hash + Display, F>(&self, tag: S, msg: F)
     where
@@ -89,30 +47,23 @@ pub trait ExecutionContextActions {
     fn continuation(&mut self, cnt: u32) -> Result<()>;
     fn ret(&mut self) -> Result<()>;
 
-    get_mem! { get_mem_i32, u32, 4 }
-    get_mem! { get_mem_i32_8s, i8, 1 }
-    get_mem! { get_mem_i32_8u, u8, 1 }
-    get_mem! { get_mem_i32_16s, i16, 2 }
-    get_mem! { get_mem_i32_16u, u16, 2 }
-    get_mem! { get_mem_i64_8s, i8, 1 }
-    get_mem! { get_mem_i64_8u, u8, 1 }
-    get_mem! { get_mem_i64_16s, i16, 2 }
-    get_mem! { get_mem_i64_16u, u16, 2 }
-    get_mem! { get_mem_i64_32s, i32, 4 }
-    get_mem! { get_mem_i64_32u, u32, 4 }
-    get_mem! { get_mem_i64, u64, 8 }
-    get_mem! { get_mem_f32, f32, 4 }
-    get_mem! { get_mem_f64, f64, 8 }
+    fn get_mem<const S: usize>(&mut self) -> Result<[u8; S]> {
+        let _a = self.op_u32()?;
+        let o = self.op_u32()?;
+        let b = self.pop::<u32>()?;
+        let i = (b + o) as usize;
+        self.mem(0)?.data[i..i + S].try_into().wrap("into")
+    }
 
-    set_mem! { set_mem_i32, u32, u32, 4 }
-    set_mem! { set_mem_i32_8, u32, u8, 1 }
-    set_mem! { set_mem_i32_16, u32, u16, 2 }
-    set_mem! { set_mem_i64, u64, u64, 8 }
-    set_mem! { set_mem_i64_8, u64, u8, 1 }
-    set_mem! { set_mem_i64_16, u64, u16, 2 }
-    set_mem! { set_mem_i64_32, u64, u32, 4 }
-    set_mem! { set_mem_f32, f32, f32, 4 }
-    set_mem! { set_mem_f64, f64, f64, 8 }
+    fn put_mem<const S: usize>(&mut self, bytes: [u8; S]) -> Result<()> {
+        let _a = self.op_u32()?;
+        let o = self.op_u32()?;
+        let b = self.pop::<u32>()?;
+        let m = self.mem(0)?;
+        let i = (o + b) as usize;
+        m.data[i..i + S].clone_from_slice(&bytes);
+        Ok(())
+    }
 }
 
 impl<'l> ExecutionContextActions for ExecutionContext<'l> {


### PR DESCRIPTION
Remove the hard-to-read macros in favor of simpler get/put mem methods
that use const generics to specify size.