### PR TITLE
Simplify instruction table error handling

### DIFF
--- a/src/format/binary/code.rs
+++ b/src/format/binary/code.rs
@@ -2,7 +2,7 @@ use super::{ensure_consumed::EnsureConsumed, values::ReadWasmValues};
 use crate::{
     err,
     error::{Result, ResultFrom},
-    instructions::{instruction_data, Operands},
+    instructions::{instruction_data, Operands, BAD_INSTRUCTION},
     syntax::{self, Continuation, Expr, FuncField, Instruction, Local, Resolved, TypeUse},
 };
 use std::{
@@ -93,7 +93,11 @@ pub trait ReadCode: ReadWasmValues {
             opcode_buf[0]
         };
 
-        let instruction_data = instruction_data(opcode)?;
+        let instruction_data = instruction_data(opcode);
+
+        if instruction_data == &BAD_INSTRUCTION {
+            return err!("Bad instruction {}", opcode);
+        }
 
         // End of expression.
         if opcode == 0x0B {

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -33,10 +33,7 @@ pub struct InstructionData {
 }
 
 /// An enum representing the different combinations of immediate operands that a WebAssembly
-/// instruction can have. There are few enough unique combinations that each one is represented by
-/// its own entry in the enum set (rather than supporting generic combinations of any of the
-/// types). The names of the enum values are from the set (U32, U64, F32, F64, Vu32, D8). Vu32
-/// stands for a Vector of U32 values. D8 indicates a byte which can just be dropped.
+/// instruction can have.
 #[derive(PartialEq, Debug)]
 pub enum Operands {
     None,
@@ -96,16 +93,12 @@ pub const BAD_INSTRUCTION: InstructionData = InstructionData {
 pub fn exec_method(opcode: u8, ec: &mut ExecutionContext) -> Result<()> {
     match EXEC_TABLE.get(opcode as usize) {
         Some(ef) => ef(ec).wrap(&format!("while executing 0x{:x}", opcode)),
-        None => err!("unhandled opcode {}", opcode),
+        None => panic!("Exec table short"),
     }
 }
 
-pub fn instruction_data<'l>(opcode: u8) -> Result<&'l InstructionData> {
-    match INSTRUCTION_DATA.get(opcode as usize) {
-        Some(id) if id == &&BAD_INSTRUCTION => err!("invalid instruction {}", opcode),
-        Some(id) => Ok(id),
-        None => err!("unhandled opcode {}", opcode),
-    }
+pub fn instruction_data(opcode: u8) -> &'static InstructionData {
+    INSTRUCTION_DATA[opcode as usize]
 }
 
 // TODO - would it be significantly more performant to build a hash map here?


### PR DESCRIPTION
If tables are short, that's an error in the build, not a runtime error.

Defer error interpretation of bad instructions to the caller.