### PR TITLE
Just emit type indices for instructions referencing function types

### DIFF
--- a/src/format/text/module_builder.rs
+++ b/src/format/text/module_builder.rs
@@ -108,10 +108,12 @@ impl ModuleBuilder {
                 Operands::CallIndirect(_, tu) => {
                     self.resolve_typeuse(tu);
                 }
-                Operands::Block(_, _, e, _) => {
+                Operands::Block(_, tu, e, _) => {
+                    self.resolve_typeuse(tu);
                     self.resolve_func_body_typeuse(e);
                 }
-                Operands::If(_, _, th, el) => {
+                Operands::If(_, tu, th, el) => {
+                    self.resolve_typeuse(tu);
                     self.resolve_func_body_typeuse(th);
                     self.resolve_func_body_typeuse(el);
                 }

--- a/src/runtime/compile.rs
+++ b/src/runtime/compile.rs
@@ -60,11 +60,7 @@ pub trait Emitter {
     ) {
         let startcnt = self.len() as u32 - 1;
 
-        let param_arity = typeuse.functiontype.params.len();
-        self.emit32(param_arity as u32);
-
-        let result_arity = typeuse.functiontype.results.len();
-        self.emit32(result_arity as u32);
+        self.emit32(typeuse.index_value());
 
         let continuation_location = self.len();
         // If the continuation is at the start, we write self the current length
@@ -96,11 +92,7 @@ pub trait Emitter {
     }
 
     fn emit_if(&mut self, typeuse: &TypeUse<Resolved>, th: &Expr<Resolved>, el: &Expr<Resolved>) {
-        let param_arity = typeuse.functiontype.params.len();
-        self.emit32(param_arity as u32);
-
-        let result_arity = typeuse.functiontype.results.len();
-        self.emit32(result_arity as u32);
+        self.emit32(typeuse.index_value());
 
         // Store the space for end continuation
         let end_location = self.len();

--- a/src/runtime/exec.rs
+++ b/src/runtime/exec.rs
@@ -256,21 +256,25 @@ impl<'l> ExecutionContextActions for ExecutionContext<'l> {
     }
 
     fn push_label_start(&mut self) -> Result<()> {
-        let param_arity = self.op_u32()?;
-        let _result_arity = self.op_u32()?;
+        let typeidx = self.op_u32()?;
         let continuation = self.op_u32()?;
+        let (param_arity, result_arity) = {
+            let functype = self.runtime.stack.get_func_type(typeidx)?;
+            (functype.params.len() as u32, functype.params.len() as u32)
+        };
         self.runtime
             .stack
-            // Subtle difference: when the continuation is the start of the block,
-            // The "result" is considered to be the parameters.
-            .push_label(param_arity, param_arity, continuation)?;
+            .push_label(param_arity, result_arity, continuation)?;
         Ok(())
     }
 
     fn push_label_end(&mut self) -> Result<()> {
-        let param_arity = self.op_u32()?;
-        let result_arity = self.op_u32()?;
+        let typeidx = self.op_u32()?;
         let continuation = self.op_u32()?;
+        let (param_arity, result_arity) = {
+            let functype = self.runtime.stack.get_func_type(typeidx)?;
+            (functype.params.len() as u32, functype.result.len() as u32)
+        };
         self.runtime
             .stack
             .push_label(param_arity, result_arity, continuation)?;

--- a/src/runtime/instance/module_instance.rs
+++ b/src/runtime/instance/module_instance.rs
@@ -29,6 +29,10 @@ pub struct ModuleInstance {
 }
 
 impl ModuleInstance {
+    pub fn func_type(&self, idx: u32) -> &FunctionType {
+        &self.types[idx as usize]
+    }
+
     pub fn func(&self, idx: u32) -> addr::FuncAddr {
         self.funcs[idx as usize]
     }

--- a/src/runtime/stack.rs
+++ b/src/runtime/stack.rs
@@ -1,8 +1,8 @@
 use super::error::Result;
 use super::ModuleInstance;
 use super::{instance::FunctionInstance, store::addr, values::Value};
-use crate::impl_bug;
 use crate::logger::{Logger, PrintLogger};
+use crate::{impl_bug, types::FunctionType};
 use std::rc::Rc;
 
 /// Besides the store, most instructions interact with an implicit stack.
@@ -237,6 +237,10 @@ impl Stack {
         let localidx = self.peek_activation()?.local_start;
         self.value_stack[localidx + idx as usize] = val;
         Ok(())
+    }
+
+    pub fn get_func_type(&self, idx: u32) -> Result<&FunctionType> {
+        Ok(self.peek_activation()?.module.func_type(idx))
     }
 
     // Get the function address for the provided index in the current activation.


### PR DESCRIPTION
Instead of argument count sizes as we are doing now.