### PR TITLE
Organize spec test runner code

### DIFF
--- a/src/spec/error.rs
+++ b/src/spec/error.rs
@@ -4,7 +4,7 @@ use crate::{
     runtime::{error::RuntimeError, values::Value},
 };
 
-use super::format::{Action, ActionResult};
+use super::format::ActionResult;
 
 #[derive(Default)]
 pub struct Failures {
@@ -41,9 +41,9 @@ pub struct Failure {
 
 #[derive(Debug)]
 pub enum SpecTestError {
-    NoModule(Action),
+    NoModule(Option<String>),
     Failures(Failures),
-    LoaderError(LoaderError),
+    LoaderError(Box<LoaderError>),
     InvocationError(RuntimeError),
     ResultLengthMismatch {
         results: Vec<Value>,
@@ -86,6 +86,6 @@ impl From<RuntimeError> for SpecTestError {
 
 impl From<LoaderError> for SpecTestError {
     fn from(e: LoaderError) -> Self {
-        SpecTestError::LoaderError(e)
+        SpecTestError::LoaderError(Box::new(e))
     }
 }

--- a/src/spec/format/mod.rs
+++ b/src/spec/format/mod.rs
@@ -114,7 +114,7 @@ impl<R: Read> Parser<R> {
             return Ok(None);
         }
 
-        let id = self.try_id()?;
+        let modname = self.try_id()?;
 
         let name = self.expect_string()?;
 
@@ -122,7 +122,11 @@ impl<R: Read> Parser<R> {
 
         self.expect_close()?;
 
-        Ok(Some(Action::Invoke { id, name, params }))
+        Ok(Some(Action::Invoke {
+            modname,
+            name,
+            params,
+        }))
     }
 
     fn try_get_action(&mut self) -> Result<Option<Action>> {
@@ -422,12 +426,12 @@ pub enum Module {
 #[derive(Debug)]
 pub enum Action {
     Invoke {
-        id: Option<String>,
+        modname: Option<String>,
         name: String,
         params: Vec<Const>,
     },
     Get {
-        id: Option<String>,
+        modname: Option<String>,
         name: String,
     },
 }

--- a/tests/spec_runner/mod.rs
+++ b/tests/spec_runner/mod.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, path::Path, time::Instant};
 
-use wrausmt::spec::runner::run_spec_test;
+use wrausmt::spec::runner::SpecTestRunner;
 use wrausmt::{format::text::lex::Tokenizer, spec::runner::RunSet};
 use wrausmt::{format::text::parse::Parser, spec::format::SpecTestScript};
 
@@ -26,6 +26,7 @@ fn parse_and_run<S: std::fmt::Debug + AsRef<Path>>(
 ) -> Result<()> {
     let f = std::fs::File::open(&path)?;
 
+    println!("\n\n*****  PARSING {:?} *****\n\n", path);
     let result = parse(f);
     let spectest = match (result, &mode) {
         (Err(e), FailMode::None) => {
@@ -38,7 +39,8 @@ fn parse_and_run<S: std::fmt::Debug + AsRef<Path>>(
 
     let start = Instant::now();
     println!("\n\n*****  RUNNING {:?} *****\n\n", path);
-    let result = run_spec_test(spectest, runset);
+    let runner = SpecTestRunner::new();
+    let result = runner.run_spec_test(spectest, runset);
     let finish = Instant::now();
     println!("TIMING {:?} IN {:?}", path, (finish - start));
     match (result, mode) {


### PR DESCRIPTION
Use a struct to collect the state maintained while running a test,
extract some helper methods.