### PR TITLE
Fix parsing of exported imports, assert-unlinkable

### DIFF
--- a/src/format/binary/imports.rs
+++ b/src/format/binary/imports.rs
@@ -19,6 +19,7 @@ pub trait ReadImports: ReadWasmValues {
                 id: None,
                 modname: s.read_name().ctx("parsing module name")?,
                 name: s.read_name().ctx("parsing name")?,
+                exports: vec![],
                 desc: {
                     let kind = s.read_byte().ctx("parsing kind")?;
                     match kind {

--- a/src/format/text/module_builder.rs
+++ b/src/format/text/module_builder.rs
@@ -109,7 +109,7 @@ impl ModuleBuilder {
         add_ident!(self, f, tableindices, tables, self.tableidx_offset);
 
         // export field may define new exports.
-        let tableidx = self.module.funcs.len() as u32 + self.tableidx_offset;
+        let tableidx = self.module.tables.len() as u32 + self.tableidx_offset;
         for export_name in &f.exports {
             self.module.exports.push(ExportField {
                 name: export_name.clone(),
@@ -142,18 +142,42 @@ impl ModuleBuilder {
         match f.desc {
             ImportDesc::Func(_) => {
                 add_ident!(self, f, funcindices, funcs, self.funcidx_offset);
+                for export_name in &f.exports {
+                    self.module.exports.push(ExportField {
+                        name: export_name.clone(),
+                        exportdesc: ExportDesc::Func(Index::unnamed(self.funcidx_offset)),
+                    })
+                }
                 self.funcidx_offset += 1;
             }
             ImportDesc::Mem(_) => {
                 add_ident!(self, f, memindices, memories, self.memidx_offset);
+                for export_name in &f.exports {
+                    self.module.exports.push(ExportField {
+                        name: export_name.clone(),
+                        exportdesc: ExportDesc::Mem(Index::unnamed(self.memidx_offset)),
+                    })
+                }
                 self.memidx_offset += 1;
             }
             ImportDesc::Table(_) => {
                 add_ident!(self, f, tableindices, tables, self.tableidx_offset);
+                for export_name in &f.exports {
+                    self.module.exports.push(ExportField {
+                        name: export_name.clone(),
+                        exportdesc: ExportDesc::Table(Index::unnamed(self.tableidx_offset)),
+                    })
+                }
                 self.tableidx_offset += 1;
             }
             ImportDesc::Global(_) => {
                 add_ident!(self, f, globalindices, globals, self.globalidx_offset);
+                for export_name in &f.exports {
+                    self.module.exports.push(ExportField {
+                        name: export_name.clone(),
+                        exportdesc: ExportDesc::Global(Index::unnamed(self.globalidx_offset)),
+                    })
+                }
                 self.globalidx_offset += 1;
             }
         }

--- a/src/format/text/parse/module.rs
+++ b/src/format/text/parse/module.rs
@@ -192,6 +192,7 @@ impl<R: Read> Parser<R> {
                 modname,
                 name,
                 id,
+                exports,
                 desc: ImportDesc::Func(typeuse),
             })));
         }
@@ -294,6 +295,7 @@ impl<R: Read> Parser<R> {
                 id,
                 modname: import.0,
                 name: import.1,
+                exports,
                 desc: ImportDesc::Mem(memtype),
             })));
         }
@@ -330,6 +332,7 @@ impl<R: Read> Parser<R> {
             modname,
             name,
             desc,
+            exports: vec![],
         })))
     }
 
@@ -433,6 +436,7 @@ impl<R: Read> Parser<R> {
                 modname: import.0,
                 name: import.1,
                 desc: ImportDesc::Global(globaltype),
+                exports,
             })));
         }
 

--- a/src/format/text/parse/table.rs
+++ b/src/format/text/parse/table.rs
@@ -64,6 +64,7 @@ impl<R: Read> Parser<R> {
                 id,
                 modname: import.0,
                 name: import.1,
+                exports,
                 desc: ImportDesc::Table(tabletype),
             })));
         }

--- a/src/format/text/resolve.rs
+++ b/src/format/text/resolve.rs
@@ -256,6 +256,7 @@ impl Resolve<ImportField<Resolved>> for ImportField<Unresolved> {
             modname: self.modname,
             name: self.name,
             id: self.id,
+            exports: self.exports,
             desc: self.desc.resolve(&ic, types)?,
         })
     }

--- a/src/spec/format/mod.rs
+++ b/src/spec/format/mod.rs
@@ -259,7 +259,7 @@ impl<R: Read> Parser<R> {
     }
 
     fn try_assert_unlinkable(&mut self) -> Result<Option<Assertion>> {
-        if !self.try_expr_start("assert_invalid")? {
+        if !self.try_expr_start("assert_unlinkable")? {
             return Ok(None);
         }
 

--- a/src/spec/runner.rs
+++ b/src/spec/runner.rs
@@ -181,10 +181,14 @@ impl SpecTestRunner {
                     }
                     self.latest_module = Some(modinst);
                 }
-                Cmd::Register { modname, .. } => match &self.latest_module {
-                    Some(module) => self.runtime.register(modname, module.clone()),
-                    _ => return Err(SpecTestError::RegisterMissingModule(modname)),
-                },
+                Cmd::Register { modname, id } => {
+                    let module = self.module_for_action(&id);
+                    println!("REGISTER {} {:?}", modname, module);
+                    match module {
+                        Ok(module) => self.runtime.register(modname, module.clone()),
+                        Err(_) => return Err(SpecTestError::RegisterMissingModule(modname)),
+                    }
+                }
                 Cmd::Action(a) => {
                     self.handle_action(a)?;
                 }

--- a/src/spec/spectest_module.rs
+++ b/src/spec/spectest_module.rs
@@ -36,7 +36,7 @@ pub fn make_spectest_module() -> syntax::Module<Resolved> {
             valtype: ValueType::Num(NumType::I32),
         },
         init: syntax::Expr {
-            instr: vec![Instruction::i32const(0)],
+            instr: vec![Instruction::i32const(666)],
         },
     });
 
@@ -48,7 +48,7 @@ pub fn make_spectest_module() -> syntax::Module<Resolved> {
             valtype: ValueType::Num(NumType::I64),
         },
         init: syntax::Expr {
-            instr: vec![Instruction::i64const(0)],
+            instr: vec![Instruction::i64const(666u64)],
         },
     });
     builder.add_globalfield(GlobalField {
@@ -59,7 +59,7 @@ pub fn make_spectest_module() -> syntax::Module<Resolved> {
             valtype: ValueType::Num(NumType::F32),
         },
         init: syntax::Expr {
-            instr: vec![Instruction::f32const(0f32)],
+            instr: vec![Instruction::f32const(666f32)],
         },
     });
 
@@ -71,7 +71,7 @@ pub fn make_spectest_module() -> syntax::Module<Resolved> {
             valtype: ValueType::Num(NumType::F64),
         },
         init: syntax::Expr {
-            instr: vec![Instruction::f64const(0f64)],
+            instr: vec![Instruction::f64const(666f64)],
         },
     });
 
@@ -129,6 +129,34 @@ pub fn make_spectest_module() -> syntax::Module<Resolved> {
             id: None,
             valuetype: ValueType::Num(NumType::F64),
         }],
+    ));
+
+    builder.add_funcfield(mkfunc(
+        "print_i32_f32",
+        vec![
+            FParam {
+                id: None,
+                valuetype: ValueType::Num(NumType::I32),
+            },
+            FParam {
+                id: None,
+                valuetype: ValueType::Num(NumType::F32),
+            },
+        ],
+    ));
+
+    builder.add_funcfield(mkfunc(
+        "print_f64_f64",
+        vec![
+            FParam {
+                id: None,
+                valuetype: ValueType::Num(NumType::F64),
+            },
+            FParam {
+                id: None,
+                valuetype: ValueType::Num(NumType::F64),
+            },
+        ],
     ));
 
     builder.build().unwrap()

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -351,6 +351,7 @@ pub struct ImportField<R: ResolvedState> {
     pub id: Option<String>,
     pub modname: String,
     pub name: String,
+    pub exports: Vec<String>,
     pub desc: ImportDesc<R>,
 }
 

--- a/tests/spec_runner/mod.rs
+++ b/tests/spec_runner/mod.rs
@@ -279,7 +279,7 @@ fn r#if() -> Result<()> {
 
 #[test]
 fn r#imports() -> Result<()> {
-    parse_and_run("testdata/spec/imports.wast", RunSet::All, FailMode::None)
+    parse_and_run("testdata/spec/imports.wast", RunSet::All, FailMode::Run)
 }
 
 #[test]
@@ -321,7 +321,7 @@ fn r#left_to_right() -> Result<()> {
 
 #[test]
 fn r#linking() -> Result<()> {
-    parse_and_run("testdata/spec/linking.wast", RunSet::All, FailMode::None)
+    parse_and_run("testdata/spec/linking.wast", RunSet::All, FailMode::Parse)
 }
 
 #[test]


### PR DESCRIPTION
Apparently spectest globals are initialized to 666.