### PR TITLE
Improve logging system

### DIFF
--- a/src/format/text/parse/num.rs
+++ b/src/format/text/parse/num.rs
@@ -44,7 +44,6 @@ impl<R: Read> Parser<R> {
 fn nanx_f64(sign: Sign, payload: &str) -> Result<f64> {
     let payload = payload.replace('_', "");
     let payload_num = u64::from_str_radix(&payload, 16)?;
-    println!("PAYLOAD NUM {:013x}", payload_num);
     let base: u64 = match sign {
         Sign::Negative => 0xFFF0000000000000,
         _ => 0x7FF0000000000000,
@@ -55,7 +54,6 @@ fn nanx_f64(sign: Sign, payload: &str) -> Result<f64> {
 fn nanx_f32(sign: Sign, payload: &str) -> Result<f32> {
     let payload = payload.replace('_', "");
     let payload_num = u32::from_str_radix(&payload, 16)?;
-    println!("PAYLOAD NUM {:06x}", payload_num);
     let base: u32 = match sign {
         Sign::Negative => 0xFF800000,
         _ => 0x7F800000,
@@ -81,7 +79,6 @@ macro_rules! parse_float {
                     match base {
                         Base::Dec => {
                             let to_parse = format!("{}{}.{}e{}", sign.char(), whole, frac, exp);
-                            println!("PARSE DECIMAL FLOAT {}", to_parse);
                             Ok(to_parse.parse::<$ty>()?)
                         }
                         Base::Hex => $hex(*sign, whole, frac, exp),
@@ -92,10 +89,7 @@ macro_rules! parse_float {
                         let to_parse = format!("{}{}", sign.char(), digits);
                         Ok(to_parse.parse::<$ty>()?)
                     }
-                    Base::Hex => {
-                        println!("TRY INT AS HEX {}", digits);
-                        $hex(*sign, digits, "", "0")
-                    }
+                    Base::Hex => $hex(*sign, digits, "", "0"),
                 },
             }
         }
@@ -216,10 +210,6 @@ impl FloatBuilder {
         let roundpart = self.bits & roundmask;
         let mantissa_lsb = self.bits & even << 1;
         let round = roundpart > even || roundpart == even && mantissa_lsb != 0;
-        println!("  SUBJECT: {:016x}", self.bits);
-        println!("ROUNDMASK: {:016x}", roundmask);
-        println!("ROUNDPART: {:016x}", roundpart);
-        println!("     EVEN: {:016x}", even);
 
         self.bits >>= 64 - size;
 
@@ -267,8 +257,6 @@ impl FloatBuilder {
 }
 
 fn parse_hex_f32(sign: Sign, whole: &str, frac: &str, exp: &str) -> Result<f32> {
-    println!("\n\nPARSE HEX F32 {:?} {} {} {}", sign, whole, frac, exp);
-
     let builder = FloatBuilder::new(whole, frac, exp)?;
 
     let mut result_bits = builder.build(f32::MANTISSA_DIGITS, 127)? as u32;
@@ -277,13 +265,10 @@ fn parse_hex_f32(sign: Sign, whole: &str, frac: &str, exp: &str) -> Result<f32> 
         result_bits |= 0x80000000;
     }
 
-    println!("f32 bits: {:08x}", result_bits);
     Ok(f32::from_bits(result_bits))
 }
 
 fn parse_hex_f64(sign: Sign, whole: &str, frac: &str, exp: &str) -> Result<f64> {
-    println!("PARSE HEX F64 {:?} {} {} {}", sign, whole, frac, exp);
-
     let builder = FloatBuilder::new(whole, frac, exp)?;
 
     let mut result_bits = builder.build(f64::MANTISSA_DIGITS, 1023)?;
@@ -292,7 +277,6 @@ fn parse_hex_f64(sign: Sign, whole: &str, frac: &str, exp: &str) -> Result<f64> 
         result_bits |= 0x8000000000000000;
     }
 
-    println!("f64 bits: {:08x}", result_bits);
     Ok(f64::from_bits(result_bits))
 }
 

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -1,35 +1,41 @@
-use std::fmt::Display;
-use std::{borrow::Borrow, collections::HashSet, hash::Hash};
-
 pub trait Logger {
-    fn log<S: Borrow<str> + Eq + Hash + Display, F>(&self, tag: S, msg: F)
-    where
-        F: Fn() -> String;
+    fn log<F: Fn() -> String>(&self, tag: Tag, msg: F);
 }
 
-#[derive(Debug, Clone)]
-pub struct PrintLogger {
-    tags: HashSet<String>,
+#[derive(Debug, Clone, Default)]
+pub struct PrintLogger;
+
+#[derive(Debug)]
+pub enum Tag {
+    Activate,
+    Enter,
+    Flow,
+    Load,
+    Local,
+    Mem,
+    Op,
+    Host,
+    Spec,
+
+    Stack,
+    LabelStack,
+    ValStack,
+    DumpStack,
+    DumpLabelStack,
+    DumpValStack,
 }
 
-impl Default for PrintLogger {
-    fn default() -> Self {
-        let mut tags = HashSet::default();
-        tags.insert("SPEC".to_owned());
-        tags.insert("LOAD".to_owned());
-        tags.insert("HOST".to_owned());
-        Self { tags }
+impl Tag {
+    fn enabled(&self) -> bool {
+        matches!(self, Tag::Load | Tag::Spec | Tag::Host)
     }
 }
 
 impl Logger for PrintLogger {
-    fn log<S: Borrow<str> + Eq + Hash + Display, F>(&self, tag: S, msg: F)
-    where
-        F: Fn() -> String,
-    {
-        if self.tags.contains(tag.borrow()) {
+    fn log<F: Fn() -> String>(&self, tag: Tag, msg: F) {
+        if tag.enabled() {
             let msg = msg();
-            println!("[{}] {}", tag, msg)
+            println!("[{:?}] {}", tag, msg)
         }
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -9,7 +9,7 @@ pub mod values;
 
 use crate::{
     impl_bug,
-    logger::{Logger, PrintLogger},
+    logger::{Logger, PrintLogger, Tag},
     runtime::error::RuntimeErrorKind,
 };
 use std::{collections::HashMap, rc::Rc};
@@ -82,7 +82,7 @@ impl Runtime {
         // Due to validation, this should be equal to the frame above.
         self.stack.pop_activation()?;
 
-        self.logger.log("ACTIVATION", || {
+        self.logger.log(Tag::Activate, || {
             format!(
                 "REMOVE FRAME {} {} {}",
                 funcinst.locals.len(),
@@ -110,7 +110,7 @@ impl Runtime {
         }?;
 
         self.logger
-            .log("HOST", || format!("calling {} at {}", name, funcaddr));
+            .log(Tag::Host, || format!("calling {} at {}", name, funcaddr));
         // 1. Assert S.funcaddr exists
         // 2. Let funcinst = S.funcs[funcaddr]
         let funcinst = self.store.func(funcaddr)?;
@@ -137,7 +137,7 @@ impl Runtime {
             let result = self.stack.pop_value()?;
 
             self.logger
-                .log("HOST", || format!("POPPED HOST RESULT {:?}", result));
+                .log(Tag::Host, || format!("POPPED HOST RESULT {:?}", result));
             results.push(result);
         }
 
@@ -170,7 +170,7 @@ impl Runtime {
         }?;
 
         self.logger
-            .log("HOST", || format!("calling {} at {}", name, globaladdr));
+            .log(Tag::Host, || format!("calling {} at {}", name, globaladdr));
         // 1. Assert S.funcaddr exists
         // 2. Let funcinst = S.funcs[funcaddr]
         let globalinst = self.store.global(globaladdr)?;

--- a/tests/meminstr32/mod.rs
+++ b/tests/meminstr32/mod.rs
@@ -15,23 +15,23 @@ fn meminstr32_get() -> Result<()> {
     exec_method!("put32", 0, 0x8176F5F3u32)?;
     let mut res1 = exec_method!("get32", 0)?;
     let v1: u32 = res1.remove(0).try_into()?;
-    assert_eq!(v1, 0x8176F5F3u32.into());
+    assert_eq!(v1, 0x8176F5F3u32);
 
     let mut res1 = exec_method!("get32_8u", 0)?;
     let v1: u32 = res1.remove(0).try_into()?;
-    assert_eq!(v1, 0xF3u32.into());
+    assert_eq!(v1, 0xF3u32);
 
     let mut res1 = exec_method!("get32_8s", 0)?;
     let v1: u32 = res1.remove(0).try_into()?;
-    assert_eq!(v1, ((0xF3 - 0x100) as u32).into());
+    assert_eq!(v1, ((0xF3 - 0x100) as u32));
 
     let mut res1 = exec_method!("get32_16u", 0)?;
     let v1: i32 = res1.remove(0).try_into()?;
-    assert_eq!(v1, 0xF5F3.into());
+    assert_eq!(v1, 0xF5F3);
 
     let mut res1 = exec_method!("get32_16s", 0)?;
     let v1: u32 = res1.remove(0).try_into()?;
-    assert_eq!(v1, ((0xF5F3 - 0x10000) as u32).into());
+    assert_eq!(v1, ((0xF5F3 - 0x10000) as u32));
 
     Ok(())
 }

--- a/tests/meminstr64/mod.rs
+++ b/tests/meminstr64/mod.rs
@@ -16,31 +16,31 @@ fn meminstr64_get() -> Result<()> {
 
     let mut res1 = exec_method!("get64", 0)?;
     let v1: u64 = res1.remove(0).try_into()?;
-    assert_eq!(v1, 0x873646368176F5F3u64.into());
+    assert_eq!(v1, 0x873646368176F5F3u64);
 
     let mut res1 = exec_method!("get64_8u", 0)?;
     let v1: u64 = res1.remove(0).try_into()?;
-    assert_eq!(v1, 0xF3u64.into());
+    assert_eq!(v1, 0xF3u64);
 
     let mut res1 = exec_method!("get64_8s", 0)?;
     let v1: u64 = res1.remove(0).try_into()?;
-    assert_eq!(v1, ((0xF3 - 0x100) as u64).into());
+    assert_eq!(v1, ((0xF3 - 0x100) as u64));
 
     let mut res1 = exec_method!("get64_16u", 0)?;
     let v1: u64 = res1.remove(0).try_into()?;
-    assert_eq!(v1, 0xF5F3u64.into());
+    assert_eq!(v1, 0xF5F3u64);
 
     let mut res1 = exec_method!("get64_16s", 0)?;
     let v1: u64 = res1.remove(0).try_into()?;
-    assert_eq!(v1, ((0xF5F3 - 0x10000) as u64).into());
+    assert_eq!(v1, ((0xF5F3 - 0x10000) as u64));
 
     let mut res1 = exec_method!("get64_32u", 0)?;
     let v1: u64 = res1.remove(0).try_into()?;
-    assert_eq!(v1, 0x8176F5F3u64.into());
+    assert_eq!(v1, 0x8176F5F3u64);
 
     let mut res1 = exec_method!("get64_32s", 0)?;
     let v1: u64 = res1.remove(0).try_into()?;
-    assert_eq!(v1, ((0x8176F5F3i64 - 0x100000000i64) as u64).into());
+    assert_eq!(v1, ((0x8176F5F3i64 - 0x100000000i64) as u64));
     Ok(())
 }
 
@@ -54,17 +54,17 @@ fn meminstr64_put() -> Result<()> {
     exec_method!("put64_8", 0, 0x873646368176F5F3u64)?;
     let mut res1 = exec_method!("get64", 0)?;
     let v1: u64 = res1.remove(0).try_into()?;
-    assert_eq!(v1, (0xF3u64).into());
+    assert_eq!(v1, (0xF3u64));
 
     exec_method!("put64_16", 0, 0x873646368176F5F3u64)?;
     let mut res1 = exec_method!("get64", 0)?;
     let v1: u64 = res1.remove(0).try_into()?;
-    assert_eq!(v1, (0xF5F3u64).into());
+    assert_eq!(v1, (0xF5F3u64));
 
     exec_method!("put64_32", 0, 0x873646368176F5F3u64)?;
     let mut res1 = exec_method!("get64", 0)?;
     let v1: u64 = res1.remove(0).try_into()?;
-    assert_eq!(v1, (0x8176F5F3u64).into());
+    assert_eq!(v1, (0x8176F5F3u64));
 
     exec_method!("put64_8", 0, 0x78u64)?;
     exec_method!("put64_8", 1, 0x56u64)?;
@@ -76,6 +76,6 @@ fn meminstr64_put() -> Result<()> {
     exec_method!("put64_8", 7, 0x77u64)?;
     let mut res1 = exec_method!("get64", 0)?;
     let v1: u64 = res1.remove(0).try_into()?;
-    assert_eq!(v1, (0x77efcdab12345678u64).into());
+    assert_eq!(v1, (0x77efcdab12345678u64));
     Ok(())
 }

--- a/tests/spec_runner/mod.rs
+++ b/tests/spec_runner/mod.rs
@@ -31,7 +31,7 @@ fn parse_and_run_for_result(mut f: File, runset: RunSet) -> SpecTestResult<()> {
     let result = runner.run_spec_test(spectest, runset);
     let finish = Instant::now();
     println!("TIMING {:?} IN {:?}", f, (finish - start));
-    Ok(result?)
+    result
 }
 
 fn parse_and_run<S: std::fmt::Debug + AsRef<Path>>(


### PR DESCRIPTION
* Hash lookups are way to slow to use for logging. Switch to tags with a boolean enable bit. This is a better log tag management approach, anyway, since we can now see all tags in one place.

* Remove a number of println! in favor of logs.

Test runtime is significantly faster now.