### PR TITLE
Spectest definition macro

### DIFF
--- a/tests/spec_runner/mod.rs
+++ b/tests/spec_runner/mod.rs
@@ -39,6 +39,7 @@ fn parse_and_run<S: std::fmt::Debug + AsRef<Path>>(
     runset: RunSet,
     mode: FailMode,
 ) -> Result<()> {
+    println!("OPENING: {:?}", path);
     let f = std::fs::File::open(&path)?;
     let result = parse_and_run_for_result(f, runset);
     let passingtext = match result {
@@ -61,498 +62,108 @@ fn parse_and_run<S: std::fmt::Debug + AsRef<Path>>(
     }
 }
 
-#[test]
-fn r#address() -> Result<()> {
-    parse_and_run("testdata/spec/address.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#align() -> Result<()> {
-    parse_and_run("testdata/spec/align.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#binary_leb128() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/binary-leb128.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#binary() -> Result<()> {
-    parse_and_run("testdata/spec/binary.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#block() -> Result<()> {
-    parse_and_run("testdata/spec/block.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#br() -> Result<()> {
-    parse_and_run("testdata/spec/br.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#br_if() -> Result<()> {
-    parse_and_run("testdata/spec/br_if.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#br_table() -> Result<()> {
-    parse_and_run("testdata/spec/br_table.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#bulk() -> Result<()> {
-    parse_and_run("testdata/spec/bulk.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#call() -> Result<()> {
-    parse_and_run("testdata/spec/call.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#call_indirect() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/call_indirect.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#comments() -> Result<()> {
-    parse_and_run("testdata/spec/comments.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#const() -> Result<()> {
-    parse_and_run("testdata/spec/const.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#conversions() -> Result<()> {
-    parse_and_run("testdata/spec/conversions.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#custom() -> Result<()> {
-    parse_and_run("testdata/spec/custom.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#data() -> Result<()> {
-    parse_and_run("testdata/spec/data.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#elem() -> Result<()> {
-    parse_and_run("testdata/spec/elem.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#endianness() -> Result<()> {
-    parse_and_run("testdata/spec/endianness.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#exports() -> Result<()> {
-    parse_and_run("testdata/spec/exports.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#f32() -> Result<()> {
-    parse_and_run("testdata/spec/f32.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#f32_bitwise() -> Result<()> {
-    parse_and_run("testdata/spec/f32_bitwise.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#f32_cmp() -> Result<()> {
-    parse_and_run("testdata/spec/f32_cmp.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#f64() -> Result<()> {
-    parse_and_run("testdata/spec/f64.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#f64_bitwise() -> Result<()> {
-    parse_and_run("testdata/spec/f64_bitwise.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#f64_cmp() -> Result<()> {
-    parse_and_run("testdata/spec/f64_cmp.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#fac() -> Result<()> {
-    parse_and_run("testdata/spec/fac.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#float_exprs() -> Result<()> {
-    parse_and_run("testdata/spec/float_exprs.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#float_literals() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/float_literals.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#float_memory() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/float_memory.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#float_misc() -> Result<()> {
-    parse_and_run("testdata/spec/float_misc.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#forward() -> Result<()> {
-    parse_and_run("testdata/spec/forward.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#func() -> Result<()> {
-    parse_and_run("testdata/spec/func.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#func_ptrs() -> Result<()> {
-    parse_and_run("testdata/spec/func_ptrs.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#global() -> Result<()> {
-    parse_and_run("testdata/spec/global.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#i32() -> Result<()> {
-    parse_and_run("testdata/spec/i32.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#i64() -> Result<()> {
-    parse_and_run("testdata/spec/i64.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#if() -> Result<()> {
-    parse_and_run("testdata/spec/if.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#imports() -> Result<()> {
-    parse_and_run("testdata/spec/imports.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#inline_module() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/inline-module.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#int_exprs() -> Result<()> {
-    parse_and_run("testdata/spec/int_exprs.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#int_literals() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/int_literals.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#labels() -> Result<()> {
-    parse_and_run("testdata/spec/labels.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#left_to_right() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/left-to-right.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#linking() -> Result<()> {
-    parse_and_run("testdata/spec/linking.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#load() -> Result<()> {
-    parse_and_run("testdata/spec/load.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#local_get() -> Result<()> {
-    parse_and_run("testdata/spec/local_get.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#local_set() -> Result<()> {
-    parse_and_run("testdata/spec/local_set.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#local_tee() -> Result<()> {
-    parse_and_run("testdata/spec/local_tee.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#loop() -> Result<()> {
-    parse_and_run("testdata/spec/loop.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#memory() -> Result<()> {
-    parse_and_run("testdata/spec/memory.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#memory_copy() -> Result<()> {
-    parse_and_run("testdata/spec/memory_copy.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#memory_fill() -> Result<()> {
-    parse_and_run("testdata/spec/memory_fill.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#memory_grow() -> Result<()> {
-    parse_and_run("testdata/spec/memory_grow.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#memory_init() -> Result<()> {
-    parse_and_run("testdata/spec/memory_init.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#memory_redundancy() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/memory_redundancy.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#memory_size() -> Result<()> {
-    parse_and_run("testdata/spec/memory_size.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#memory_trap() -> Result<()> {
-    parse_and_run("testdata/spec/memory_trap.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#names() -> Result<()> {
-    parse_and_run("testdata/spec/names.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#nop() -> Result<()> {
-    parse_and_run("testdata/spec/nop.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#ref_func() -> Result<()> {
-    parse_and_run("testdata/spec/ref_func.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#ref_is_null() -> Result<()> {
-    parse_and_run("testdata/spec/ref_is_null.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#ref_null() -> Result<()> {
-    parse_and_run("testdata/spec/ref_null.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#return() -> Result<()> {
-    parse_and_run("testdata/spec/return.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#select() -> Result<()> {
-    parse_and_run("testdata/spec/select.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#skip_stack_guard_page() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/skip-stack-guard-page.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#stack() -> Result<()> {
-    parse_and_run("testdata/spec/stack.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#start() -> Result<()> {
-    parse_and_run("testdata/spec/start.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#store() -> Result<()> {
-    parse_and_run("testdata/spec/store.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#switch() -> Result<()> {
-    parse_and_run("testdata/spec/switch.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#table_sub() -> Result<()> {
-    parse_and_run("testdata/spec/table-sub.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#table() -> Result<()> {
-    parse_and_run("testdata/spec/table.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#table_copy() -> Result<()> {
-    parse_and_run("testdata/spec/table_copy.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#table_fill() -> Result<()> {
-    parse_and_run("testdata/spec/table_fill.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#table_get() -> Result<()> {
-    parse_and_run("testdata/spec/table_get.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#table_grow() -> Result<()> {
-    parse_and_run("testdata/spec/table_grow.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#table_init() -> Result<()> {
-    parse_and_run("testdata/spec/table_init.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#table_set() -> Result<()> {
-    parse_and_run("testdata/spec/table_set.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#table_size() -> Result<()> {
-    parse_and_run("testdata/spec/table_size.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#token() -> Result<()> {
-    parse_and_run("testdata/spec/token.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#traps() -> Result<()> {
-    parse_and_run("testdata/spec/traps.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#type() -> Result<()> {
-    parse_and_run("testdata/spec/type.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#unreachable() -> Result<()> {
-    parse_and_run("testdata/spec/unreachable.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#unreached_invalid() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/unreached-invalid.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#unwind() -> Result<()> {
-    parse_and_run("testdata/spec/unwind.wast", RunSet::All, FailMode::Run)
-}
-
-#[test]
-fn r#utf8_custom_section_id() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/utf8-custom-section-id.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#utf8_import_field() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/utf8-import-field.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#utf8_import_module() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/utf8-import-module.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
-
-#[test]
-fn r#utf8_invalid_encoding() -> Result<()> {
-    parse_and_run(
-        "testdata/spec/utf8-invalid-encoding.wast",
-        RunSet::All,
-        FailMode::Run,
-    )
-}
+// To regenerate the spectest! lines below using the transform this macro expects:
+// "".join(["spectest!(r#{});  ".format(i.replace(".wast","").replace("-","_x_")) for i in sorted(os.listdir('testdata/spec'))])
+macro_rules! spectest {
+    ($name:ident; [$runset:expr]; [$failmode:expr]) => {
+        #[test]
+        fn $name() -> Result<()> {
+            parse_and_run(
+                format!("testdata/spec/{}.wast", stringify!($name)[2..].replace("_x_", "-")),
+                $runset,
+                $failmode,
+            )
+        }
+    };
+    ($name:ident) => { spectest!($name; [RunSet::All]; [FailMode::Run]); };
+    ($name:ident; [$runset:expr]) => { spectest!($name; [$runset]; [FailMode::Run]); };
+    ($name:ident; []; $failmode:expr) => { spectest!($name; [RunSet::All]; [$failmode]); };
+}
+spectest!(r#address);
+spectest!(r#align);
+spectest!(r#binary_x_leb128);
+spectest!(r#binary);
+spectest!(r#block);
+spectest!(r#br);
+spectest!(r#br_if);
+spectest!(r#br_table);
+spectest!(r#bulk);
+spectest!(r#call);
+spectest!(r#call_indirect);
+spectest!(r#comments);
+spectest!(r#const);
+spectest!(r#conversions);
+spectest!(r#custom);
+spectest!(r#data);
+spectest!(r#elem);
+spectest!(r#endianness);
+spectest!(r#exports);
+spectest!(r#f32);
+spectest!(r#f32_bitwise);
+spectest!(r#f32_cmp);
+spectest!(r#f64);
+spectest!(r#f64_bitwise);
+spectest!(r#f64_cmp);
+spectest!(r#fac);
+spectest!(r#float_exprs);
+spectest!(r#float_literals);
+spectest!(r#float_memory);
+spectest!(r#float_misc);
+spectest!(r#forward);
+spectest!(r#func);
+spectest!(r#func_ptrs);
+spectest!(r#global);
+spectest!(r#i32);
+spectest!(r#i64);
+spectest!(r#if);
+spectest!(r#imports);
+spectest!(r#inline_x_module);
+spectest!(r#int_exprs);
+spectest!(r#int_literals);
+spectest!(r#labels);
+spectest!(r#left_x_to_x_right);
+spectest!(r#linking);
+spectest!(r#load);
+spectest!(r#local_get);
+spectest!(r#local_set);
+spectest!(r#local_tee);
+spectest!(r#loop);
+spectest!(r#memory);
+spectest!(r#memory_copy);
+spectest!(r#memory_fill);
+spectest!(r#memory_grow);
+spectest!(r#memory_init);
+spectest!(r#memory_redundancy);
+spectest!(r#memory_size);
+spectest!(r#memory_trap);
+spectest!(r#names);
+spectest!(r#nop);
+spectest!(r#ref_func);
+spectest!(r#ref_is_null);
+spectest!(r#ref_null);
+spectest!(r#return);
+spectest!(r#select);
+spectest!(r#skip_x_stack_x_guard_x_page);
+spectest!(r#stack);
+spectest!(r#start);
+spectest!(r#store);
+spectest!(r#switch);
+spectest!(r#table_x_sub);
+spectest!(r#table);
+spectest!(r#table_copy);
+spectest!(r#table_fill);
+spectest!(r#table_get);
+spectest!(r#table_grow);
+spectest!(r#table_init);
+spectest!(r#table_set);
+spectest!(r#table_size);
+spectest!(r#token);
+spectest!(r#traps);
+spectest!(r#type);
+spectest!(r#unreachable);
+spectest!(r#unreached_x_invalid);
+spectest!(r#unwind);
+spectest!(r#utf8_x_custom_x_section_x_id);
+spectest!(r#utf8_x_import_x_field);
+spectest!(r#utf8_x_import_x_module);
+spectest!(r#utf8_x_invalid_x_encoding);


### PR DESCRIPTION
There's a little bit of hackery involved, but it's good enough!

The main blocker is that some filenames use -, but others use _. So we can't use replace - with _ and then change it back.

The goal is to not have to update any file names after re-importing new tests.