### PR TITLE
Generic types cleanup (#178)

### DIFF
--- a/src/format/text/mod.rs
+++ b/src/format/text/mod.rs
@@ -1,6 +1,7 @@
 use crate::format::text::parse::error::Result;
 use crate::syntax::{Module, Resolved};
 
+use self::parse::error::{ParseError, ParseErrorKind};
 use self::{lex::Tokenizer, parse::Parser};
 use std::io::Read;
 
@@ -14,7 +15,8 @@ pub mod resolve;
 pub mod string;
 
 pub fn parse_wast_data(reader: &mut impl Read) -> Result<Module<Resolved>> {
-    let tokenizer = Tokenizer::new(reader)?;
+    let tokenizer = Tokenizer::new(reader)
+        .map_err(|e| ParseError::new_nocontext(ParseErrorKind::LexError(e)))?;
     let mut parser = Parser::new(tokenizer)?;
     parser.parse_full_module()
 }

--- a/src/format/text/parse/instruction.rs
+++ b/src/format/text/parse/instruction.rs
@@ -1,6 +1,5 @@
 use super::Parser;
 use super::Result;
-use crate::format::text::parse::error::ParseError;
 use crate::format::text::token::Token;
 use crate::syntax::{self, Continuation, Expr, Index, Instruction, Unresolved};
 use crate::{instructions::instruction_by_name, instructions::Operands};
@@ -72,7 +71,7 @@ impl<R: Read> Parser<R> {
                         let tabidx = self.try_index()?;
                         let elemidx = self.try_index()?;
                         let (tabidx, elemidx) = match (tabidx, elemidx) {
-                            (None, None) => return Err(ParseError::unexpected("elem idx")),
+                            (None, None) => return Err(self.unexpected_token("elem idx")),
                             (None, Some(elemidx)) => (Index::unnamed(0), elemidx),
                             (Some(tabidx), None) => (Index::unnamed(0), tabidx.convert()),
                             (Some(tabidx), Some(elemidx)) => (tabidx, elemidx),
@@ -107,7 +106,7 @@ impl<R: Read> Parser<R> {
                 self.try_id()?;
                 Ok(())
             }
-            None => Err(ParseError::unexpected("end")),
+            None => Err(self.unexpected_token("end")),
         }
     }
 
@@ -213,7 +212,7 @@ impl<R: Read> Parser<R> {
             self.expect_close()?;
             Expr { instr }
         } else {
-            return Err(ParseError::unexpected("then"));
+            return Err(self.unexpected_token("then"));
         };
         let elexpr = if self.try_expr_start("else")? {
             let instr = self.zero_or_more_groups(Self::try_instruction)?;

--- a/src/format/text/parse/valtype.rs
+++ b/src/format/text/parse/valtype.rs
@@ -1,5 +1,5 @@
 use super::super::token::Token;
-use super::error::{ParseError, Result};
+use super::error::{ParseErrorKind, Result};
 use super::Parser;
 use crate::types::{NumType, RefType, ValueType};
 use std::io::Read;
@@ -7,7 +7,9 @@ use std::io::Read;
 impl<R: Read> Parser<R> {
     pub fn expect_valtype(&mut self) -> Result<ValueType> {
         self.try_valtype()?
-            .ok_or_else(|| ParseError::unexpected("value type"))
+            .ok_or(self.err(ParseErrorKind::UnexpectedToken(
+                "expected value type".into(),
+            )))
     }
 
     pub fn try_valtype(&mut self) -> Result<Option<ValueType>> {
@@ -31,7 +33,7 @@ impl<R: Read> Parser<R> {
 
     pub fn expect_reftype(&mut self) -> Result<RefType> {
         self.try_reftype()?
-            .ok_or_else(|| ParseError::unexpected("value type"))
+            .ok_or(self.err(ParseErrorKind::UnexpectedToken("expected ref type".into())))
     }
 
     pub fn try_reftype(&mut self) -> Result<Option<RefType>> {
@@ -66,6 +68,6 @@ impl<R: Read> Parser<R> {
 
     pub fn expect_heaptype(&mut self) -> Result<RefType> {
         self.try_heaptype()?
-            .ok_or_else(|| ParseError::unexpected("heaptype"))
+            .ok_or(self.err(ParseErrorKind::UnexpectedToken("expected heap type".into())))
     }
 }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -1,11 +1,13 @@
+use crate::format::text::lex::error::LexError;
+use crate::format::text::parse::error::ParseErrorKind;
 /// The loader module is the bridge between the format parsing code, and the
 /// runtime, which expects a fully resolved module as input.
 use crate::format::{
     binary::error::BinaryParseError, binary::parse_wasm_data, text::parse::error::ParseError,
     text::parse_wast_data,
 };
+use crate::runtime::error::RuntimeError;
 use crate::runtime::{instance::ModuleInstance, Runtime};
-use crate::{format::text::lex::error::LexError, runtime::error::RuntimeError};
 use std::fs::File;
 use std::io::Read;
 use std::rc::Rc;
@@ -38,15 +40,15 @@ impl From<std::io::Error> for LoaderError {
     }
 }
 
-impl From<LexError> for LoaderError {
-    fn from(e: LexError) -> Self {
-        LoaderError::ParseError(e.into())
-    }
-}
-
 impl From<ParseError> for LoaderError {
     fn from(e: ParseError) -> Self {
         LoaderError::ParseError(e)
+    }
+}
+
+impl From<LexError> for LoaderError {
+    fn from(e: LexError) -> Self {
+        LoaderError::ParseError(ParseError::new_nocontext(ParseErrorKind::LexError(e)))
     }
 }
 

--- a/tests/parse/mod.rs
+++ b/tests/parse/mod.rs
@@ -1,18 +1,20 @@
 use std::fs::File;
 
-use wrausmt::format::text::parse::error::Result;
+use wrausmt::format::text::parse::error::KindResult;
 use wrausmt::format::text::parse_wast_data;
 use wrausmt::format::text::token::Token;
 use wrausmt::format::text::{lex::Tokenizer, token::NumToken};
+use wrausmt::loader::Result as LoadResult;
 use wrausmt::syntax::{Module, Resolved};
 use wrausmt::typefield;
 
-fn load_ast(filename: &str) -> Result<Module<Resolved>> {
-    parse_wast_data(&mut File::open(filename)?)
+fn load_ast(filename: &str) -> LoadResult<Module<Resolved>> {
+    let loaded = parse_wast_data(&mut File::open(filename)?)?;
+    Ok(loaded)
 }
 
 #[test]
-fn basic_parse() -> Result<()> {
+fn basic_parse() -> LoadResult<()> {
     let module = load_ast("testdata/locals.wat")?;
 
     println!("{:?}", module);
@@ -30,27 +32,27 @@ fn basic_parse() -> Result<()> {
 }
 
 #[test]
-fn block_parse() -> Result<()> {
+fn block_parse() -> LoadResult<()> {
     let module = load_ast("testdata/plainblock.wat")?;
     println!("{:?}", module);
     Ok(())
 }
 
 #[test]
-fn folded_block_parse() -> Result<()> {
+fn folded_block_parse() -> LoadResult<()> {
     let module = load_ast("testdata/foldedblock.wat")?;
     println!("{:?}", module);
     Ok(())
 }
 
 #[test]
-fn table_parse() -> Result<()> {
+fn table_parse() -> LoadResult<()> {
     let module = load_ast("testdata/table.wat")?;
     println!("{:?}", module);
     Ok(())
 }
 
-fn parse_numtoken(src: &str) -> Result<NumToken> {
+fn parse_numtoken(src: &str) -> KindResult<NumToken> {
     let mut tokenizer = Tokenizer::new(src.as_bytes())?;
     match tokenizer.next().unwrap()?.token {
         Token::Number(nt) => Ok(nt),
@@ -59,7 +61,7 @@ fn parse_numtoken(src: &str) -> Result<NumToken> {
 }
 
 #[test]
-fn parse_number() -> Result<()> {
+fn parse_number() -> KindResult<()> {
     let tok = parse_numtoken("-600")?;
     assert_eq!(tok.as_i32()?, -600);
     assert_eq!(tok.as_i64()?, -600);


### PR DESCRIPTION
Clean up ParseError structure for easier comparison in tests
    
    * Use the "kind" approach where error types are a field in a single
      ParseError struct that also contains context.
    * New helpers for creating and adding context.
    * Clean out unused pieces.