### PR TITLE
Refactor align/offset parsing

### DIFF
--- a/src/format/text/lex/mod.rs
+++ b/src/format/text/lex/mod.rs
@@ -39,6 +39,19 @@ fn keyword_or_reserved(idchars: Id) -> Token {
     }
 }
 
+fn maybe_align_or_offset(idchars: &Id) -> Option<Token> {
+    if idchars.data().get(0..6) == Some(b"align=") {
+        if let Some(n) = num::maybe_number_at(idchars, 6) {
+            return Some(Token::Align(n));
+        }
+    } else if idchars.data().get(0..7) == Some(b"offset=") {
+        if let Some(n) = num::maybe_number_at(idchars, 7) {
+            return Some(Token::Offset(n));
+        }
+    }
+    None
+}
+
 impl<R: Read> Tokenizer<R> {
     pub fn new(r: R) -> Result<Tokenizer<R>> {
         let mut tokenizer = Tokenizer {
@@ -69,6 +82,9 @@ impl<R: Read> Tokenizer<R> {
                     return Ok(Token::Id(idchars));
                 }
                 if let Some(n) = num::maybe_number(&idchars) {
+                    return Ok(Token::Number(n));
+                }
+                if let Some(n) = maybe_align_or_offset(&idchars) {
                     return Ok(n);
                 }
                 Ok(keyword_or_reserved(idchars))

--- a/src/format/text/lex/num.rs
+++ b/src/format/text/lex/num.rs
@@ -1,9 +1,6 @@
-use {
-    super::Token,
-    crate::{
-        format::text::token::{Base, NumToken, Sign},
-        syntax::Id,
-    },
+use crate::{
+    format::text::token::{Base, NumToken, Sign},
+    syntax::Id,
 };
 
 fn is_digit(ch: char, hex: bool) -> bool {
@@ -64,9 +61,19 @@ impl<'a> StrCursor<'a> {
 
 /// Attempt to interpret the `idchars` as a number. If the conversion is
 /// successful, a [Token] is returned, otherwise, [None] is returned.
-pub fn maybe_number(idchars: &Id) -> Option<Token> {
+pub fn maybe_number(idchars: &Id) -> Option<NumToken> {
     let mut cursor = StrCursor::new(idchars.as_str());
+    maybe_number_cursor(&mut cursor)
+}
 
+/// Like maybe_number, but starting at the `idx`th character in the idchars.
+pub fn maybe_number_at(idchars: &Id, idx: usize) -> Option<NumToken> {
+    let mut cursor = StrCursor::new(idchars.as_str());
+    cursor.advance_by(idx);
+    maybe_number_cursor(&mut cursor)
+}
+
+fn maybe_number_cursor(cursor: &mut StrCursor) -> Option<NumToken> {
     let sign: Sign = cursor.cur().unwrap().into();
 
     if sign != Sign::Unspecified {
@@ -74,18 +81,18 @@ pub fn maybe_number(idchars: &Id) -> Option<Token> {
     }
 
     if cursor.is_exactly("nan") {
-        return Some(Token::Number(NumToken::NaN(sign)));
+        return Some(NumToken::NaN(sign));
     }
 
     if cursor.is_exactly("inf") {
-        return Some(Token::Number(NumToken::Inf(sign)));
+        return Some(NumToken::Inf(sign));
     }
 
     if cursor.matches("nan:0x") {
         cursor.advance_by(6);
         let payload = cursor.consume_while(|c| is_digit(c, true));
         return match cursor.is_empty() {
-            true => Some(Token::Number(NumToken::NaNx(sign, payload))),
+            true => Some(NumToken::NaNx(sign, payload)),
             false => None,
         };
     }
@@ -128,8 +135,8 @@ pub fn maybe_number(idchars: &Id) -> Option<Token> {
     }
 
     if have_point || have_exp {
-        Some(Token::Number(NumToken::Float(sign, base, whole, frac, exp)))
+        Some(NumToken::Float(sign, base, whole, frac, exp))
     } else {
-        Some(Token::Number(NumToken::Integer(sign, base, whole)))
+        Some(NumToken::Integer(sign, base, whole))
     }
 }

--- a/src/format/text/parse/instruction.rs
+++ b/src/format/text/parse/instruction.rs
@@ -149,29 +149,23 @@ impl<R: Read> Parser<R> {
     }
 
     fn try_align(&mut self) -> Result<Option<u32>> {
-        if let Some(kw) = self.take_keyword_if(|kw| kw.as_str().starts_with("align="))? {
-            if let Some(idx) = kw.as_str().find('=') {
-                let (_, valstr) = kw.as_str().split_at(idx + 1);
-                if let Ok(val) = valstr.parse() {
-                    return Ok(Some(val));
-                }
-            }
-        }
+        let n = match self.current.token {
+            Token::Align(ref n) => n.as_u32().map_err(|k| self.err(k))?,
+            _ => return Ok(None),
+        };
 
-        Ok(None)
+        self.advance()?;
+        Ok(Some(n))
     }
 
     fn try_offset(&mut self) -> Result<Option<u32>> {
-        if let Some(kw) = self.take_keyword_if(|kw| kw.as_str().starts_with("offset="))? {
-            if let Some(idx) = kw.as_str().find('=') {
-                let (_, valstr) = kw.as_str().split_at(idx + 1);
-                if let Ok(val) = valstr.parse() {
-                    return Ok(Some(val));
-                }
-            }
-        }
+        let n = match self.current.token {
+            Token::Offset(ref n) => n.as_u32().map_err(|k| self.err(k))?,
+            _ => return Ok(None),
+        };
 
-        Ok(None)
+        self.advance()?;
+        Ok(Some(n))
     }
 
     pub fn try_plain_instruction_as_single(

--- a/src/format/text/token.rs
+++ b/src/format/text/token.rs
@@ -50,6 +50,10 @@ pub enum Token {
     LineComment,
     BlockComment,
     Keyword(Id),
+    // By the spec, align= and offset= phrases are keywords. However, lexing
+    // them now as tokens makes the number parsing more straightforward later.
+    Align(NumToken),
+    Offset(NumToken),
     Reserved(String),
     Number(NumToken),
     String(WasmString),


### PR DESCRIPTION
During parsing, the full number parser wasn't used, just the rust parser; so it was missing align/offset values represented as hex.