### PR TITLE
Fixing numeric parsing of align/offset

### DIFF
--- a/src/format/text/lex/mod.rs
+++ b/src/format/text/lex/mod.rs
@@ -1,21 +1,19 @@
-use self::error::LexError;
-
 use {
-    super::token::{FileToken, Token},
+    self::error::LexError,
+    super::{
+        num,
+        token::{FileToken, Token},
+    },
     crate::{
         format::{text::string::WasmString, Location},
         syntax::Id,
     },
-};
-mod chars;
-pub mod error;
-mod num;
-
-use {
     chars::CharChecks,
     error::{Result, WithContext},
     std::{io::Read, iter::Iterator},
 };
+mod chars;
+pub mod error;
 
 #[cfg(test)]
 mod test;
@@ -68,8 +66,8 @@ impl<R: Read> Tokenizer<R> {
                 if idchars.data()[0] == b'$' {
                     return Ok(Token::Id(idchars));
                 }
-                if let Some(n) = num::maybe_number(&idchars) {
-                    return Ok(n);
+                if let Some(n) = num::maybe_number(idchars.as_str()) {
+                    return Ok(Token::Number(n));
                 }
                 Ok(keyword_or_reserved(idchars))
             }

--- a/src/format/text/mod.rs
+++ b/src/format/text/mod.rs
@@ -15,6 +15,7 @@ use {
 };
 
 pub mod lex;
+pub mod num;
 pub mod token;
 
 pub mod macros;

--- a/src/format/text/num.rs
+++ b/src/format/text/num.rs
@@ -1,10 +1,4 @@
-use {
-    super::Token,
-    crate::{
-        format::text::token::{Base, NumToken, Sign},
-        syntax::Id,
-    },
-};
+use crate::format::text::token::{Base, NumToken, Sign};
 
 fn is_digit(ch: char, hex: bool) -> bool {
     if matches!(ch, '0'..='9' | '_') {
@@ -64,8 +58,8 @@ impl<'a> StrCursor<'a> {
 
 /// Attempt to interpret the `idchars` as a number. If the conversion is
 /// successful, a [Token] is returned, otherwise, [None] is returned.
-pub fn maybe_number(idchars: &Id) -> Option<Token> {
-    let mut cursor = StrCursor::new(idchars.as_str());
+pub fn maybe_number(idchars: &str) -> Option<NumToken> {
+    let mut cursor = StrCursor::new(idchars);
 
     let sign: Sign = cursor.cur().unwrap().into();
 
@@ -74,18 +68,18 @@ pub fn maybe_number(idchars: &Id) -> Option<Token> {
     }
 
     if cursor.is_exactly("nan") {
-        return Some(Token::Number(NumToken::NaN(sign)));
+        return Some(NumToken::NaN(sign));
     }
 
     if cursor.is_exactly("inf") {
-        return Some(Token::Number(NumToken::Inf(sign)));
+        return Some(NumToken::Inf(sign));
     }
 
     if cursor.matches("nan:0x") {
         cursor.advance_by(6);
         let payload = cursor.consume_while(|c| is_digit(c, true));
         return match cursor.is_empty() {
-            true => Some(Token::Number(NumToken::NaNx(sign, payload))),
+            true => Some(NumToken::NaNx(sign, payload)),
             false => None,
         };
     }
@@ -128,8 +122,8 @@ pub fn maybe_number(idchars: &Id) -> Option<Token> {
     }
 
     if have_point || have_exp {
-        Some(Token::Number(NumToken::Float(sign, base, whole, frac, exp)))
+        Some(NumToken::Float(sign, base, whole, frac, exp))
     } else {
-        Some(Token::Number(NumToken::Integer(sign, base, whole)))
+        Some(NumToken::Integer(sign, base, whole))
     }
 }

--- a/src/format/text/parse/mod.rs
+++ b/src/format/text/parse/mod.rs
@@ -202,7 +202,7 @@ impl<R: Read> Parser<R> {
         }
     }
 
-    pub fn take_keyword_if(&mut self, pred: fn(&Id) -> bool) -> Result<Option<Id>> {
+    pub fn take_keyword_if(&mut self, pred: impl Fn(&Id) -> bool) -> Result<Option<Id>> {
         match self.current.token {
             Token::Keyword(ref mut id) if pred(id) => {
                 let id = std::mem::take(id);


### PR DESCRIPTION
    Fixing numeric parsing of align/offset
    
    We need to use the WASM parser, not the rust parser, since they could be
    in hex.
    
    Since the num parsing code is used by the parer and the lexer, it's
    moved up a level now.