### PR TITLE
Use str repr internally and verify the received Id chars

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
@@ -66,7 +66,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/format/src/binary/elems.rs
+++ b/format/src/binary/elems.rs
@@ -6,8 +6,8 @@ use {
     },
     crate::binary::error::BinaryParseError,
     wrausmt_runtime::syntax::{
-        self, types::RefType, ElemField, ElemList, Expr, FuncIndex, Index, Instruction, ModeEntry,
-        Opcode, Resolved, TablePosition, TableUse,
+        self, types::RefType, ElemField, ElemList, Expr, FuncIndex, Id, Index, Instruction,
+        ModeEntry, Opcode, Resolved, TablePosition, TableUse,
     },
 };
 
@@ -69,7 +69,7 @@ pub trait ReadElems: ReadWasmValues + ReadCode {
             .into_iter()
             .map(|idx| Expr {
                 instr: vec![Instruction {
-                    name:     "ref.func".into(),
+                    name:     Id::literal("ref.func"),
                     opcode:   Opcode::Normal(0xD2),
                     operands: syntax::Operands::FuncIndex(idx),
                 }],

--- a/format/src/text/lex/error.rs
+++ b/format/src/text/lex/error.rs
@@ -2,7 +2,8 @@
 pub enum LexError {
     WithContext(Vec<String>, Box<LexError>),
     IoError(std::io::Error),
-    Utf8Error(std::string::FromUtf8Error),
+    FromUtf8Error(std::string::FromUtf8Error),
+    Utf8Error(std::str::Utf8Error),
     UnexpectedChar(char),
     InvalidEscape(String),
 }
@@ -50,6 +51,12 @@ impl From<std::io::Error> for LexError {
 
 impl From<std::string::FromUtf8Error> for LexError {
     fn from(e: std::string::FromUtf8Error) -> Self {
+        LexError::FromUtf8Error(e)
+    }
+}
+
+impl From<std::str::Utf8Error> for LexError {
+    fn from(e: std::str::Utf8Error) -> Self {
         LexError::Utf8Error(e)
     }
 }

--- a/format/src/text/lex/mod.rs
+++ b/format/src/text/lex/mod.rs
@@ -28,10 +28,10 @@ pub struct Tokenizer<R> {
 }
 
 fn keyword_or_reserved(idchars: Id) -> Token {
-    if idchars.data()[0].is_keyword_start() {
+    if idchars[0].is_keyword_start() {
         Token::Keyword(idchars)
     } else {
-        Token::Reserved(idchars.as_str().into())
+        Token::Reserved(idchars.as_str().to_owned())
     }
 }
 
@@ -61,7 +61,7 @@ impl<R: Read> Tokenizer<R> {
                 .ctx("while consuming line comment"),
             b if b.is_idchar() => {
                 let idchars = self.consume_idchars().ctx("while reading next token")?;
-                if idchars.data()[0] == b'$' {
+                if idchars[0] == b'$' {
                     return Ok(Token::Id(idchars));
                 }
                 if let Some(n) = num::maybe_number(idchars.as_str()) {
@@ -205,7 +205,7 @@ impl<R: Read> Tokenizer<R> {
             result.push(self.current);
             self.advance()?;
         }
-        Ok(result.into())
+        Ok(result.try_into()?)
     }
 
     /// Handler for a '(' - if followed by ';, consumes a block comment and

--- a/format/src/text/lex/test.rs
+++ b/format/src/text/lex/test.rs
@@ -8,6 +8,7 @@ use {
         string::WasmString,
         token::{Base, NumToken},
     },
+    wrausmt_runtime::syntax::Id,
 };
 
 macro_rules! expect_tokens {
@@ -30,7 +31,7 @@ fn simple_parse() -> Result<()> {
     expect_tokens!(
         "(foo) \"hello\" (5.6 -0xF 0xF) (; comment (; nested ;) more ;)\n(yay)",
         Token::Open,
-        Token::Keyword("foo".into()),
+        Token::Keyword(Id::literal("foo")),
         Token::Close,
         Token::Whitespace,
         Token::String(WasmString::from_bytes("hello".as_bytes().into())),
@@ -52,7 +53,7 @@ fn simple_parse() -> Result<()> {
         Token::BlockComment,
         Token::Whitespace,
         Token::Open,
-        Token::Keyword("yay".into()),
+        Token::Keyword(Id::literal("yay")),
         Token::Close
     );
     Ok(())

--- a/format/src/text/macros.rs
+++ b/format/src/text/macros.rs
@@ -7,7 +7,7 @@
 #[macro_export]
 macro_rules! fparam {
     ( $pid:literal; $vt:ident ) => {
-        wrausmt_runtime::fparam! { Some($pid.into()); $vt }
+        wrausmt_runtime::fparam! { Some($pid); $vt }
     };
     ( $id:expr; Func ) => {
         wrausmt_runtime::syntax::FParam {
@@ -44,7 +44,9 @@ macro_rules! fresult {
 #[macro_export]
 macro_rules! typefield {
     ( $id:literal; [$( $pt:ident $($pid:literal)?),*] -> [$($rt:ident),*] ) => {
-        typefield! { Some($id.into()); [$($pt $($pid.into())?)*] -> [$($rt)*] }
+        typefield! {
+            Some(wrausmt::syntax::Id::literal($id)); [$($pt $($pid.into())?)*] -> [$($rt)*]
+         }
     };
     ( [$($pt:ident $($pid:literal)?),*] -> [$($rt:ident),*] ) => {
         typefield! { None; [$($pt $($pid)?)*] -> [$($rt)*] }
@@ -53,7 +55,9 @@ macro_rules! typefield {
         wrausmt_runtime::syntax::TypeField {
             id: $id,
             functiontype: $crate::syntax::FunctionType {
-                params: vec![$(wrausmt_runtime::fparam! { $($pid;)? $pt })*],
+                params: vec![$(wrausmt_runtime::fparam! {
+                    $(Some(wrausmt::syntax::Id::literal($pid));)? $pt
+                })*],
                 results: vec![$(wrausmt_runtime::fresult! { $rt })*],
             }
         }

--- a/format/src/text/parse/mod.rs
+++ b/format/src/text/parse/mod.rs
@@ -108,12 +108,12 @@ impl<R: Read> Parser<R> {
         println!("POSITION {:?} {:?}", self.current, self.next);
     }
 
-    pub fn try_expr_start(&mut self, name: impl Into<Id>) -> Result<bool> {
+    pub fn try_expr_start(&mut self, name: &str) -> Result<bool> {
         if self.current.token != Token::Open {
             return Ok(false);
         }
         match &self.next.token {
-            Token::Keyword(k) if k == &name.into() => {
+            Token::Keyword(k) if k.as_str() == name => {
                 self.advance()?;
                 self.advance()?;
                 Ok(true)
@@ -122,17 +122,17 @@ impl<R: Read> Parser<R> {
         }
     }
 
-    pub fn peek_expr_start(&mut self, name: impl Into<Id>) -> Result<bool> {
+    pub fn peek_expr_start(&mut self, name: &str) -> Result<bool> {
         if self.current.token != Token::Open {
             return Ok(false);
         }
         match &self.next.token {
-            Token::Keyword(k) if k == &name.into() => Ok(true),
+            Token::Keyword(k) if k.as_str() == name => Ok(true),
             _ => Ok(false),
         }
     }
 
-    fn expect_expr_start(&mut self, name: impl Into<Id>) -> Result<()> {
+    fn expect_expr_start(&mut self, name: &str) -> Result<()> {
         if !self.try_expr_start(name)? {
             Err(self.unexpected_token("expression start"))
         } else {

--- a/format/src/text/resolve.rs
+++ b/format/src/text/resolve.rs
@@ -141,7 +141,7 @@ macro_rules! index_resolver {
                 $ic: &ResolutionContext,
                 _: &mut Vec<TypeField>,
             ) -> Result<Index<Resolved, $it>> {
-                let value = if self.name().data().is_empty() {
+                let value = if self.name().as_str().is_empty() {
                     self.value()
                 } else {
                     // TODO - how to handle the different index types?

--- a/format/src/text/token.rs
+++ b/format/src/text/token.rs
@@ -34,11 +34,6 @@ impl<IC: Into<char>> From<IC> for Sign {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum Reserved {
-    Id,
-    String,
-}
 /// An enum of all of the possible lexical tokens that can occur in a
 /// WebAssembly text file.
 #[derive(Clone, Debug, PartialEq)]

--- a/wrausmt-runtime/src/instructions/mod.rs
+++ b/wrausmt-runtime/src/instructions/mod.rs
@@ -134,7 +134,7 @@ pub fn instruction_by_name(name: &Id) -> Option<&'static InstructionData> {
         .iter()
         .chain(EXTENDED_INSTRUCTION_DATA.iter())
         .chain(SIMD_INSTRUCTION_DATA.iter())
-        .find(|&item| item.name.as_bytes() == name.data())
+        .find(|&item| item.name == name.as_str())
 }
 
 pub mod op_consts {


### PR DESCRIPTION
Use str repr internally and verify the received Id chars

For now there's an Id::literal constructor, but it will fail at runtime if a
literal is provided with invalid chars.

This will be improved later with a macro.