### PR TITLE
Simplify Tokenizer and Parser constructor to not throw error

### DIFF
--- a/tests-spec/src/format/mod.rs
+++ b/tests-spec/src/format/mod.rs
@@ -51,6 +51,7 @@ pub trait SpecParser {
 
 impl<R: Read> SpecParser for Parser<R> {
     fn parse_spec_test(&mut self) -> Result<SpecTestScript> {
+        self.assure_started()?;
         match self.zero_or_more(Parser::try_cmd_entry) {
             Ok(cmds) => {
                 if self.current.token != Token::Eof {

--- a/tests-spec/src/loader.rs
+++ b/tests-spec/src/loader.rs
@@ -5,15 +5,11 @@ use {
     },
     crate::runner::{RunSet, SpecTestRunner},
     std::{fs::File, path::Path},
-    wrausmt_format::{
-        loader::Result as LoaderResult,
-        text::{lex::Tokenizer, parse::Parser},
-    },
+    wrausmt_format::{loader::Result as LoaderResult, text::parse::Parser},
 };
 
 pub fn parse(f: &mut File) -> LoaderResult<SpecTestScript> {
-    let tokenizer = Tokenizer::new(f)?;
-    let mut parser = Parser::new(tokenizer)?;
+    let mut parser = Parser::new(f);
     let result = parser.parse_spec_test()?;
     Ok(result)
 }

--- a/wrausmt-format/src/loader.rs
+++ b/wrausmt-format/src/loader.rs
@@ -1,11 +1,8 @@
 /// The loader module is the bridge between the format parsing code, and the
 /// runtime, which expects a fully resolved module as input.
 use crate::{
-    binary::error::BinaryParseError,
-    binary::parse_wasm_data,
-    text::parse::error::ParseError,
+    binary::error::BinaryParseError, binary::parse_wasm_data, text::parse::error::ParseError,
     text::parse_wast_data,
-    text::{lex::error::LexError, parse::error::ParseErrorKind},
 };
 use {
     std::{fs::File, io::Read, rc::Rc},
@@ -43,12 +40,6 @@ impl From<std::io::Error> for LoaderError {
 impl From<ParseError> for LoaderError {
     fn from(e: ParseError) -> Self {
         LoaderError::ParseError(e)
-    }
-}
-
-impl From<LexError> for LoaderError {
-    fn from(e: LexError) -> Self {
-        LoaderError::ParseError(ParseError::new_nocontext(ParseErrorKind::LexError(e)))
     }
 }
 

--- a/wrausmt-format/src/text/lex/error.rs
+++ b/wrausmt-format/src/text/lex/error.rs
@@ -6,6 +6,7 @@ pub enum LexError {
     Utf8Error(std::str::Utf8Error),
     UnexpectedChar(char),
     InvalidEscape(String),
+    UnexpectedEof,
 }
 
 pub type Result<T> = std::result::Result<T, LexError>;

--- a/wrausmt-format/src/text/lex/mod.rs
+++ b/wrausmt-format/src/text/lex/mod.rs
@@ -36,19 +36,20 @@ fn keyword_or_reserved(idchars: Id) -> Token {
 }
 
 impl<R: Read> Tokenizer<R> {
-    pub fn new(r: R) -> Result<Tokenizer<R>> {
-        let mut tokenizer = Tokenizer {
+    pub fn new(r: R) -> Tokenizer<R> {
+        Tokenizer {
             inner:    r,
             current:  0,
             eof:      false,
             location: Location::default(),
-        };
-        tokenizer.location.nextline();
-        tokenizer.advance()?;
-        Ok(tokenizer)
+        }
     }
 
     fn next_token(&mut self) -> Result<Token> {
+        if self.location.line == 0 {
+            self.location.nextline();
+            self.advance()?;
+        }
         if self.current.is_whitespace() {
             return self.consume_whitespace();
         }
@@ -83,7 +84,7 @@ impl<R: Read> Tokenizer<R> {
         self.current = buf[0];
         if amount_read == 0 {
             if self.eof {
-                panic!("unexpected eof");
+                return Err(LexError::UnexpectedEof);
             } else {
                 self.eof = true;
             }

--- a/wrausmt-format/src/text/lex/test.rs
+++ b/wrausmt-format/src/text/lex/test.rs
@@ -13,7 +13,7 @@ use {
 
 macro_rules! expect_tokens {
     ( $to_parse:expr, $($t:expr),* ) => {
-        let mut tokenizer = Tokenizer::new($to_parse.as_bytes())?;
+        let mut tokenizer = Tokenizer::new($to_parse.as_bytes());
         $(
             let rtok = tokenizer.next();
             match rtok {

--- a/wrausmt-format/src/text/mod.rs
+++ b/wrausmt-format/src/text/mod.rs
@@ -1,11 +1,5 @@
 use {
-    self::{
-        lex::Tokenizer,
-        parse::{
-            error::{ParseError, ParseErrorKind},
-            Parser,
-        },
-    },
+    self::parse::Parser,
     super::text::parse::error::Result,
     std::io::Read,
     wrausmt_runtime::syntax::{Module, Resolved},
@@ -22,8 +16,6 @@ pub mod resolve;
 pub mod string;
 
 pub fn parse_wast_data(reader: &mut impl Read) -> Result<Module<Resolved>> {
-    let tokenizer = Tokenizer::new(reader)
-        .map_err(|e| ParseError::new_nocontext(ParseErrorKind::LexError(e)))?;
-    let mut parser = Parser::new(tokenizer)?;
+    let mut parser = Parser::new(reader);
     parser.parse_full_module()
 }

--- a/wrausmt-format/src/text/parse/error.rs
+++ b/wrausmt-format/src/text/parse/error.rs
@@ -37,13 +37,6 @@ pub struct ParseError {
 }
 
 impl ParseError {
-    pub fn new_nocontext(kind: ParseErrorKind) -> Self {
-        Self {
-            kind,
-            ..Default::default()
-        }
-    }
-
     pub fn new(kind: ParseErrorKind, context: ParseContext) -> Self {
         Self {
             kind,

--- a/wrausmt-format/src/text/parse/mod.rs
+++ b/wrausmt-format/src/text/parse/mod.rs
@@ -51,15 +51,24 @@ impl<T, E: Into<ParseErrorKind>> ParseResult<T> for std::result::Result<T, E> {
 
 // Implementation for the basic token-handling methods.
 impl<R: Read> Parser<R> {
-    pub fn new(tokenizer: Tokenizer<R>) -> Result<Parser<R>> {
-        let mut p = Parser {
+    pub fn new_from_tokenizer(tokenizer: Tokenizer<R>) -> Parser<R> {
+        Parser {
             tokenizer,
             current: FileToken::default(),
             next: FileToken::default(),
-        };
-        p.advance()?;
-        p.advance()?;
-        Ok(p)
+        }
+    }
+
+    pub fn new(reader: R) -> Parser<R> {
+        Parser::new_from_tokenizer(Tokenizer::new(reader))
+    }
+
+    pub fn assure_started(&mut self) -> Result<()> {
+        if self.current.token == Token::Start {
+            self.advance()?;
+            self.advance()?;
+        }
+        Ok(())
     }
 
     pub fn err(&self, err: ParseErrorKind) -> ParseError {

--- a/wrausmt-format/src/text/parse/module.rs
+++ b/wrausmt-format/src/text/parse/module.rs
@@ -46,6 +46,8 @@ impl<R: Read> Parser<R> {
     }
 
     pub fn parse_full_module(&mut self) -> Result<Module<Resolved>> {
+        self.assure_started()?;
+
         match self.try_module() {
             Ok(Some(m)) => {
                 if self.current.token != Token::Eof {

--- a/wrausmt-format/src/text/token.rs
+++ b/wrausmt-format/src/text/token.rs
@@ -36,8 +36,9 @@ impl<IC: Into<char>> From<IC> for Sign {
 
 /// An enum of all of the possible lexical tokens that can occur in a
 /// WebAssembly text file.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub enum Token {
+    #[default]
     Start,
     Whitespace,
     LineComment,
@@ -74,13 +75,6 @@ pub enum NumToken {
     Inf(Sign),
     Integer(Sign, Base, String),
     Float(Sign, Base, String, String, String),
-}
-
-impl Default for Token {
-    /// Returns a default token of [Token::Start].
-    fn default() -> Token {
-        Token::Start
-    }
 }
 
 impl Location {


### PR DESCRIPTION
The states are initialized on first use, instead.
