### PR TITLE
Fix malformed alignment value tests

### DIFF
--- a/tests-spec/tests/main.rs
+++ b/tests-spec/tests/main.rs
@@ -23,8 +23,8 @@ macro_rules! nomalformed {
     };
 }
 
-spectest!(r#address; [nomalformed!("i32 constant")]);
-spectest!(r#align; [nomalformed!("alignment")]);
+spectest!(r#address);
+spectest!(r#align);
 spectest!(r#binary_x_leb128; [nomalformed!(
     "integer representation too long",
     "integer too large"

--- a/wrausmt-format/src/text/parse/error.rs
+++ b/wrausmt-format/src/text/parse/error.rs
@@ -25,6 +25,7 @@ pub enum ParseErrorKind {
     Utf8Error(FromUtf8Error),
     ParseIntError(ParseIntError),
     ParseFloatError(ParseFloatError),
+    InvalidAlignment(u32),
     TooManyLocals,
     Incomplete,
 }


### PR DESCRIPTION
Note that this is different from *invalid* alignment for a given
instruction, which is checked during validation. The alignment must be a
power of 2 in all cases.

Fix fixes all malformed cases for address and alignment.
