### PR TITLE
Fix malformed unxpected token tests

### DIFF
--- a/tests-spec/src/runner.rs
+++ b/tests-spec/src/runner.rs
@@ -137,6 +137,7 @@ impl MalformedMatch for str {
         match self {
             "alignment" => matches!(parse_err, Some(ParseErrorKind::InvalidAlignment(_))),
             "i32 constant" => matches!(parse_err, Some(ParseErrorKind::ParseIntError(_))),
+            "unexpected token" => matches!(parse_err, Some(ParseErrorKind::UnexpectedToken(_))),
             _ => false,
         }
     }

--- a/tests-spec/tests/main.rs
+++ b/tests-spec/tests/main.rs
@@ -50,15 +50,15 @@ spectest!(r#binary; [nomalformed!(
     "integer representation too long",
     "unexpected content after last section"
 )]);
-spectest!(r#block; [nomalformed!("unexpected token", "inline function type", "mismatching label")]);
+spectest!(r#block; [nomalformed!("inline function type", "mismatching label")]);
 spectest!(r#br);
 spectest!(r#br_if);
 spectest!(r#br_table);
 spectest!(r#bulk);
 spectest!(r#call);
-spectest!(r#call_indirect; [nomalformed!("unexpected token", "inline function type")]);
+spectest!(r#call_indirect; [nomalformed!("inline function type")]);
 spectest!(r#comments);
-spectest!(r#const; [nomalformed!("unknown operator", "unexpected token", "constant out of range")]);
+spectest!(r#const; [nomalformed!("unknown operator", "constant out of range")]);
 spectest!(r#conversions);
 spectest!(r#custom; [nomalformed!(
     "unexpected end",
@@ -71,10 +71,10 @@ spectest!(r#data);
 spectest!(r#elem);
 spectest!(r#endianness);
 spectest!(r#exports);
-spectest!(r#f32; [nomalformed!("unexpected token")]);
+spectest!(r#f32);
 spectest!(r#f32_bitwise);
 spectest!(r#f32_cmp);
-spectest!(r#f64; [nomalformed!("unexpected token")]);
+spectest!(r#f64);
 spectest!(r#f64_bitwise);
 spectest!(r#f64_cmp);
 spectest!(r#fac);
@@ -84,18 +84,16 @@ spectest!(r#float_memory);
 spectest!(r#float_misc);
 spectest!(r#forward);
 spectest!(r#func; [nomalformed!(
-    "unexpected token",
     "inline function type",
     "duplicate func",
     "duplicate local",
-    "unknown type",
-    "unexpected token"
+    "unknown type"
 )]);
 spectest!(r#func_ptrs);
 spectest!(r#global; [nomalformed!("malformed mutability", "duplicate global")]);
-spectest!(r#i32; [nomalformed!("unexpected token")]);
-spectest!(r#i64; [nomalformed!("unexpected token")]);
-spectest!(r#if; [nomalformed!("unexpected token", "inline function type", "mismatching label")]);
+spectest!(r#i32);
+spectest!(r#i64);
+spectest!(r#if; [nomalformed!("inline function type", "mismatching label")]);
 spectest!(r#imports; [nomalformed!("import after function", "import after global", "import after table", "import after memory")]);
 spectest!(r#inline_x_module);
 spectest!(r#int_exprs);
@@ -107,7 +105,7 @@ spectest!(r#load; [nomalformed!("unknown operator")]);
 spectest!(r#local_get);
 spectest!(r#local_set);
 spectest!(r#local_tee);
-spectest!(r#loop; [nomalformed!("unexpected token", "inline function type", "mismatching label")]);
+spectest!(r#loop; [nomalformed!("inline function type", "mismatching label")]);
 spectest!(r#memory; [nomalformed!("i32 constant out of range", "duplicate memory")]);
 spectest!(r#memory_copy);
 spectest!(r#memory_fill);
@@ -140,7 +138,7 @@ spectest!(r#table_set);
 spectest!(r#table_size);
 spectest!(r#token; [nomalformed!("unknown operator", "unknown label")]);
 spectest!(r#traps);
-spectest!(r#type; [nomalformed!("unexpected token")]);
+spectest!(r#type);
 spectest!(r#unreachable);
 spectest!(r#unreached_x_invalid);
 spectest!(r#unreached_x_valid);

--- a/wrausmt-format/src/text/parse/instruction.rs
+++ b/wrausmt-format/src/text/parse/instruction.rs
@@ -58,7 +58,7 @@ impl<R: Read> Parser<R> {
                     }
                     Operands::CallIndirect => {
                         let idx = self.try_index()?.unwrap_or_else(|| Index::unnamed(0));
-                        let typeuse = self.parse_type_use()?;
+                        let typeuse = self.parse_type_use(super::module::FParamId::Forbidden)?;
                         syntax::Operands::CallIndirect(idx, typeuse)
                     }
                     Operands::I32 => syntax::Operands::I32(self.expect_i32()? as u32),
@@ -115,7 +115,7 @@ impl<R: Read> Parser<R> {
 
     fn parse_plain_block(&mut self, cnt: Continuation) -> Result<syntax::Operands<Unresolved>> {
         let label = self.try_id()?;
-        let typeuse = self.parse_type_use()?;
+        let typeuse = self.parse_type_use(super::module::FParamId::Forbidden)?;
         let instr = self.parse_instructions()?;
         self.expect_plain_end()?;
 
@@ -125,7 +125,7 @@ impl<R: Read> Parser<R> {
     fn parse_plain_if_operands(&mut self) -> Result<syntax::Operands<Unresolved>> {
         let label = self.try_id()?;
 
-        let typeuse = self.parse_type_use()?;
+        let typeuse = self.parse_type_use(super::module::FParamId::Forbidden)?;
 
         let thengroup = self.parse_instructions()?;
 
@@ -192,7 +192,7 @@ impl<R: Read> Parser<R> {
         cnt: Continuation,
     ) -> Result<Instruction<Unresolved>> {
         let label = self.try_id()?;
-        let typeuse = self.parse_type_use()?;
+        let typeuse = self.parse_type_use(super::module::FParamId::Forbidden)?;
         let instr = self.parse_instructions()?;
         self.expect_close()?;
         let operands = syntax::Operands::Block(label, typeuse, Expr { instr }, cnt);
@@ -205,7 +205,7 @@ impl<R: Read> Parser<R> {
 
     fn parse_folded_if(&mut self) -> Result<Vec<Instruction<Unresolved>>> {
         let label = self.try_id()?;
-        let typeuse = self.parse_type_use()?;
+        let typeuse = self.parse_type_use(super::module::FParamId::Forbidden)?;
         let condition = self.zero_or_more_groups(Self::try_folded_instruction)?;
         let mut unfolded = condition;
         let thexpr = if self.try_expr_start("then")? {


### PR DESCRIPTION
* Map the error in the spec runner
* Fix a parsing bug: in sme positions, params are not allowed to have IDs
  attached.
