### PR TITLE
Simplify ignorable consumption

### DIFF
--- a/wrausmt-format/src/text/lex/test.rs
+++ b/wrausmt-format/src/text/lex/test.rs
@@ -33,9 +33,7 @@ fn simple_parse() -> Result<()> {
         Token::Open,
         Token::Keyword(Id::literal("foo")),
         Token::Close,
-        Token::Whitespace,
         Token::String(WasmString::from_bytes("hello".as_bytes().into())),
-        Token::Whitespace,
         Token::Open,
         Token::Number(NumToken::Float(
             Sign::Unspecified,
@@ -44,14 +42,9 @@ fn simple_parse() -> Result<()> {
             "6".into(),
             "".into()
         )),
-        Token::Whitespace,
         Token::Number(NumToken::Integer(Sign::Negative, Base::Hex, "F".into())),
-        Token::Whitespace,
         Token::Number(NumToken::Integer(Sign::Unspecified, Base::Hex, "F".into())),
         Token::Close,
-        Token::Whitespace,
-        Token::BlockComment,
-        Token::Whitespace,
         Token::Open,
         Token::Keyword(Id::literal("yay")),
         Token::Close

--- a/wrausmt-format/src/text/parse/mod.rs
+++ b/wrausmt-format/src/text/parse/mod.rs
@@ -34,10 +34,7 @@ impl Ignorable for Token {
     /// Returns true if the token is ignorable (whitespace, start, or comment)
     /// by the parser.
     fn ignorable(&self) -> bool {
-        matches!(
-            self,
-            Token::Start | Token::Whitespace | Token::LineComment | Token::BlockComment
-        )
+        matches!(self, Token::Start)
     }
 }
 

--- a/wrausmt-format/src/text/token.rs
+++ b/wrausmt-format/src/text/token.rs
@@ -40,9 +40,6 @@ impl<IC: Into<char>> From<IC> for Sign {
 pub enum Token {
     #[default]
     Start,
-    Whitespace,
-    LineComment,
-    BlockComment,
     Keyword(Id),
     Reserved(String),
     Number(NumToken),


### PR DESCRIPTION
There's no need to generate tokens, and we can just consume it all
quickly before parsing another token.

Switch lexer to have 1-char lookahead to simplify comment parsing.
