### PR TITLE
Properly announce invalid operators, fix issues that come up.

### DIFF
--- a/tests-spec/src/runner.rs
+++ b/tests-spec/src/runner.rs
@@ -137,7 +137,14 @@ impl MalformedMatch for str {
         match self {
             "alignment" => matches!(parse_err, Some(ParseErrorKind::InvalidAlignment(_))),
             "i32 constant" => matches!(parse_err, Some(ParseErrorKind::ParseIntError(_))),
-            "unexpected token" => matches!(parse_err, Some(ParseErrorKind::UnexpectedToken(_))),
+            "unexpected token" => matches!(
+                parse_err,
+                // This should really only be unexpected token, but blocks end up parsing
+                // out-of-order param/result/type as instructions. One approach to improve this
+                // coudl be to define all of the non-instruction keywords as their own tokens.
+                Some(ParseErrorKind::UnexpectedToken(_))
+                    | Some(ParseErrorKind::UnrecognizedInstruction(_))
+            ),
             _ => false,
         }
     }

--- a/wrausmt-format/src/text/parse/instruction.rs
+++ b/wrausmt-format/src/text/parse/instruction.rs
@@ -100,7 +100,9 @@ impl<R: Read> Parser<R> {
                     operands,
                 }))
             }
-            None => Ok(None),
+            None => Err(self.err(ParseErrorKind::UnrecognizedInstruction(
+                name.as_str().into(),
+            ))),
         }
     }
 
@@ -253,7 +255,7 @@ impl<R: Read> Parser<R> {
     // loop <label> <bt> <instr>* end
     // <folded>* if <label> <bt> <instr>* <else <instr*>>? end
     // (if <label> <bt> <folded>* (then <instr>*) (else <instr>*)?)
-    fn try_folded_instruction(&mut self) -> Result<Option<Vec<Instruction<Unresolved>>>> {
+    pub fn try_folded_instruction(&mut self) -> Result<Option<Vec<Instruction<Unresolved>>>> {
         pctx!(self, "try folded instruction");
         if self.current.token != Token::Open {
             return Ok(None);


### PR DESCRIPTION
* Was not parsing the single-instruction special form of `item` or
  `offset` correctly.
