### PR TITLE
Use tracer for binary parser

### DIFF
--- a/wrausmt-format/src/binary/custom.rs
+++ b/wrausmt-format/src/binary/custom.rs
@@ -1,17 +1,15 @@
 use {
-    super::{
-        error::{Result, WithContext},
-        BinaryParser,
-    },
+    super::{error::Result, BinaryParser},
+    crate::{binary::error::ParseResult, pctx},
     std::io::Read,
 };
 
 /// Read a custom section, which is interpreted as a simple vec(bytes)
 impl<R: Read> BinaryParser<R> {
     pub(in crate::binary) fn read_custom_section(&mut self) -> Result<Box<[u8]>> {
+        pctx!(self, "read custom section");
         let mut section: Vec<u8> = vec![];
-        self.read_to_end(&mut section)
-            .ctx("reading custom content")?;
+        self.read_to_end(&mut section).result(self)?;
         Ok(section.into_boxed_slice())
     }
 }

--- a/wrausmt-format/src/binary/exports.rs
+++ b/wrausmt-format/src/binary/exports.rs
@@ -1,8 +1,9 @@
 use {
     super::{
-        error::{BinaryParseErrorKind, Result, WithContext},
+        error::{BinaryParseErrorKind, Result},
         BinaryParser,
     },
+    crate::pctx,
     std::io::Read,
     wrausmt_runtime::syntax::{ExportDesc, ExportField, Resolved},
 };
@@ -23,25 +24,21 @@ impl<R: Read> BinaryParser<R> {
     }
 
     fn read_export_desc(&mut self) -> Result<ExportDesc<Resolved>> {
-        let kind = self.read_byte().ctx("parsing kind")?;
+        pctx!(self, "read exprt desc");
+        let kind = self.read_byte()?;
         match kind {
-            0 => Ok(ExportDesc::Func(self.read_index_use().ctx("parsing func")?)),
-            1 => Ok(ExportDesc::Table(
-                self.read_index_use().ctx("parsing table")?,
-            )),
-            2 => Ok(ExportDesc::Mem(
-                self.read_index_use().ctx("parsing memory")?,
-            )),
-            3 => Ok(ExportDesc::Global(
-                self.read_index_use().ctx("parsing global")?,
-            )),
-            _ => Err(BinaryParseErrorKind::InvalidExportType(kind).into()),
+            0 => Ok(ExportDesc::Func(self.read_index_use()?)),
+            1 => Ok(ExportDesc::Table(self.read_index_use()?)),
+            2 => Ok(ExportDesc::Mem(self.read_index_use()?)),
+            3 => Ok(ExportDesc::Global(self.read_index_use()?)),
+            _ => Err(self.err(BinaryParseErrorKind::InvalidExportType(kind))),
         }
     }
 
     fn read_export_field(&mut self) -> Result<ExportField<Resolved>> {
+        pctx!(self, "read exprt field");
         Ok(ExportField {
-            name:       self.read_name().ctx("parsing name")?,
+            name:       self.read_name()?,
             exportdesc: self.read_export_desc()?,
         })
     }

--- a/wrausmt-format/src/binary/funcs.rs
+++ b/wrausmt-format/src/binary/funcs.rs
@@ -1,8 +1,6 @@
 use {
-    super::{
-        error::{Result, WithContext},
-        BinaryParser,
-    },
+    super::{error::Result, BinaryParser},
+    crate::pctx,
     std::io::Read,
     wrausmt_runtime::syntax::{Index, Resolved, TypeIndex},
 };
@@ -12,9 +10,8 @@ impl<R: Read> BinaryParser<R> {
     /// Read a funcs section. This is just a vec(TypeIndex).
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.
-    pub(in crate::binary) fn read_funcs_section(
-        &mut self,
-    ) -> Result<Vec<Index<Resolved, TypeIndex>>> {
-        self.read_vec(|_, s| s.read_index_use().ctx("parsing func"))
+    pub fn read_funcs_section(&mut self) -> Result<Vec<Index<Resolved, TypeIndex>>> {
+        pctx!(self, "read funcs section");
+        self.read_vec(|_, s| s.read_index_use())
     }
 }

--- a/wrausmt-format/src/binary/globals.rs
+++ b/wrausmt-format/src/binary/globals.rs
@@ -1,5 +1,6 @@
 use {
     super::{error::Result, BinaryParser},
+    crate::pctx,
     std::io::Read,
     wrausmt_runtime::syntax::{GlobalField, Resolved},
 };
@@ -10,10 +11,12 @@ impl<R: Read> BinaryParser<R> {
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.
     pub(in crate::binary) fn read_globals_section(&mut self) -> Result<Vec<GlobalField<Resolved>>> {
+        pctx!(self, "read globals section");
         self.read_vec(|_, s| s.read_global_field())
     }
 
     fn read_global_field(&mut self) -> Result<GlobalField<Resolved>> {
+        pctx!(self, "read global field");
         Ok(GlobalField {
             id:         None,
             exports:    vec![],

--- a/wrausmt-format/src/binary/mems.rs
+++ b/wrausmt-format/src/binary/mems.rs
@@ -1,5 +1,6 @@
 use {
     super::{error::Result, BinaryParser},
+    crate::pctx,
     std::io::Read,
     wrausmt_runtime::syntax::MemoryField,
 };
@@ -10,10 +11,12 @@ impl<R: Read> BinaryParser<R> {
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.
     pub(in crate::binary) fn read_mems_section(&mut self) -> Result<Vec<MemoryField>> {
+        pctx!(self, "read mems section");
         self.read_vec(|_, s| s.read_memory_field())
     }
 
     fn read_memory_field(&mut self) -> Result<MemoryField> {
+        pctx!(self, "read memory field");
         Ok(MemoryField {
             id:      None,
             memtype: self.read_memory_type()?,

--- a/wrausmt-format/src/binary/start.rs
+++ b/wrausmt-format/src/binary/start.rs
@@ -1,5 +1,6 @@
 use {
     super::{error::Result, BinaryParser},
+    crate::pctx,
     std::io::Read,
     wrausmt_runtime::syntax::{Resolved, StartField},
 };
@@ -10,6 +11,7 @@ impl<R: Read> BinaryParser<R> {
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.
     pub(in crate::binary) fn read_start_section(&mut self) -> Result<StartField<Resolved>> {
+        pctx!(self, "read start");
         Ok(StartField {
             idx: self.read_index_use()?,
         })

--- a/wrausmt-format/src/binary/tables.rs
+++ b/wrausmt-format/src/binary/tables.rs
@@ -1,8 +1,6 @@
 use {
-    super::{
-        error::{Result, WithContext},
-        BinaryParser,
-    },
+    super::{error::Result, BinaryParser},
+    crate::pctx,
     std::io::Read,
     wrausmt_runtime::syntax::TableField,
 };
@@ -13,10 +11,12 @@ impl<R: Read> BinaryParser<R> {
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.
     pub(in crate::binary) fn read_tables_section(&mut self) -> Result<Vec<TableField>> {
-        self.read_vec(|_, s| s.read_table_field().ctx("read table type"))
+        pctx!(self, "read tables section");
+        self.read_vec(|_, s| s.read_table_field())
     }
 
     fn read_table_field(&mut self) -> Result<TableField> {
+        pctx!(self, "read table field");
         Ok(TableField {
             id:        None,
             tabletype: self.read_table_type()?,

--- a/wrausmt-format/src/binary/values.rs
+++ b/wrausmt-format/src/binary/values.rs
@@ -1,9 +1,10 @@
 use {
     super::{
-        error::{BinaryParseError, BinaryParseErrorKind, Result, WithContext},
+        error::{BinaryParseErrorKind, Result},
         leb128::ReadLeb128,
         BinaryParser,
     },
+    crate::{binary::error::ParseResult, pctx},
     std::{io::Read, marker::Sized},
     wrausmt_runtime::syntax::{
         types::{NumType, RefType, ValueType},
@@ -14,9 +15,9 @@ use {
 macro_rules! read_exact_bytes {
     ( $r:expr, $size:expr, $expect:expr ) => {{
         let mut buf = [0u8; $size];
-        $r.read_exact(&mut buf).ctx("reading")?;
+        $r.read_exact(&mut buf).result($r)?;
         if buf != $expect {
-            Err(BinaryParseError::new(BinaryParseErrorKind::Unexpected {
+            Err($r.err(BinaryParseErrorKind::Unexpected {
                 got:    Box::new(buf),
                 expect: Box::new($expect),
             }))
@@ -29,37 +30,44 @@ macro_rules! read_exact_bytes {
 /// A collection of read helpers used by the various section reader traits.
 impl<R: Read> BinaryParser<R> {
     pub(in crate::binary) fn read_magic(&mut self) -> Result<()> {
-        read_exact_bytes!(self, 4, [0x00, 0x61, 0x73, 0x6d]).ctx("wrong magic")
+        pctx!(self, "read magic");
+        read_exact_bytes!(self, 4, [0x00, 0x61, 0x73, 0x6d])
     }
 
     pub(in crate::binary) fn read_version(&mut self) -> Result<()> {
-        read_exact_bytes!(self, 4, [0x01, 0x00, 0x00, 0x00]).ctx("unsupported version")
+        pctx!(self, "read version");
+        read_exact_bytes!(self, 4, [0x01, 0x00, 0x00, 0x00])
     }
 
     /// Read a single byte, returning an errror for EOF.
     pub(in crate::binary) fn read_byte(&mut self) -> Result<u8> {
+        pctx!(self, "read byte");
         let mut buf = [0u8; 1];
-        self.read_exact(&mut buf).ctx("reading next byte")?;
+        self.read_exact(&mut buf).result(self)?;
         Ok(buf[0])
     }
 
     /// Read a single byte, returning an error if it doesn't match the value
     /// provided.
     pub(in crate::binary) fn read_specific_byte(&mut self, expect: u8) -> Result<()> {
+        pctx!(self, "read specific byte");
         read_exact_bytes!(self, 1, [expect])
     }
 
     /// Read a "name" field.
     /// Names are encoded as a vec(byte).
     pub(in crate::binary) fn read_name(&mut self) -> Result<String> {
+        pctx!(self, "read name");
         let bs = self.read_bytes()?;
-        String::from_utf8(bs.to_vec()).ctx("parsing name data")
+        let r = String::from_utf8(bs.to_vec()).result(self)?;
+        Ok(r)
     }
 
     pub(in crate::binary) fn read_bytes(&mut self) -> Result<Box<[u8]>> {
-        let length = self.read_u32_leb_128().ctx("parsing length")?;
+        pctx!(self, "read bytes");
+        let length = self.read_u32_leb_128().result(self)?;
         let mut bs: Vec<u8> = vec![0; length as usize];
-        self.read_exact(&mut bs).ctx("reading name data")?;
+        self.read_exact(&mut bs).result(self)?;
         Ok(bs.into_boxed_slice())
     }
 
@@ -67,63 +75,70 @@ impl<R: Read> BinaryParser<R> {
     /// A boolean field should only contain a value of 1 (for true) or 0 (for
     /// false).
     pub(in crate::binary) fn read_bool(&mut self) -> Result<bool> {
-        let bool_byte = self.read_byte().ctx("fetching bool")?;
+        pctx!(self, "read bool");
+        let bool_byte = self.read_byte()?;
         match bool_byte {
             0 => Ok(false),
             1 => Ok(true),
-            _ => Err(BinaryParseErrorKind::InvalidBoolValue(bool_byte).into()),
+            _ => Err(self.err(BinaryParseErrorKind::InvalidBoolValue(bool_byte))),
         }
     }
 
     pub(in crate::binary) fn read_value_type(&mut self) -> Result<ValueType> {
-        ValueType::interpret(self.read_byte().ctx("fetching value type")?)
+        pctx!(self, "read value type");
+        let b = self.read_byte()?;
+        ValueType::interpret(b).ok_or(self.err(BinaryParseErrorKind::InvalidValueType(b)))
     }
 
     pub(in crate::binary) fn read_ref_type(&mut self) -> Result<RefType> {
-        RefType::interpret(self.read_byte().ctx("fetching ref type")?)
+        pctx!(self, "read ref type");
+        let b = self.read_byte()?;
+        RefType::interpret(b).ok_or(self.err(BinaryParseErrorKind::InvalidRefType(b)))
     }
 
     pub(in crate::binary) fn read_vec<T>(
         &mut self,
         f: impl Fn(u32, &mut Self) -> Result<T>,
     ) -> Result<Vec<T>> {
-        let item_count = self.read_u32_leb_128().ctx("parsing count")?;
+        pctx!(self, "read vec");
+        let item_count = self.read_u32_leb_128().result(self)?;
         (0..item_count).map(|i| f(i, self)).collect()
     }
 
     pub(in crate::binary) fn read_index_use<IS: IndexSpace>(
         &mut self,
     ) -> Result<Index<Resolved, IS>> {
-        Ok(Index::unnamed(self.read_u32_leb_128().ctx("leb128")?))
+        pctx!(self, "read index use");
+        Ok(Index::unnamed(self.read_u32_leb_128().result(self)?))
     }
 }
 
 trait Interpret<T> {
-    fn interpret(t: T) -> Result<Self>
+    fn interpret(t: T) -> Option<Self>
     where
         Self: Sized;
 }
 
 impl Interpret<u8> for ValueType {
-    fn interpret(byte: u8) -> Result<ValueType> {
+    fn interpret(byte: u8) -> Option<ValueType> {
         match byte {
-            0x7F => Ok(NumType::I32.into()),
-            0x7E => Ok(NumType::I64.into()),
-            0x7D => Ok(NumType::F32.into()),
-            0x7C => Ok(NumType::F64.into()),
-            0x70 => Ok(RefType::Func.into()),
-            0x6F => Ok(RefType::Extern.into()),
-            _ => Err(BinaryParseErrorKind::InvalidValueType(byte).into()),
+            0x7F => Some(NumType::I32.into()),
+            0x7E => Some(NumType::I64.into()),
+            0x7D => Some(NumType::F32.into()),
+            0x7C => Some(NumType::F64.into()),
+            0x70 => Some(RefType::Func.into()),
+            0x6F => Some(RefType::Extern.into()),
+            _ => None,
         }
     }
 }
 
 impl Interpret<u8> for RefType {
-    fn interpret(byte: u8) -> Result<RefType> {
+    fn interpret(byte: u8) -> Option<RefType> {
         match byte {
-            0x70 => Ok(RefType::Func),
-            0x6F => Ok(RefType::Extern),
-            _ => Err(BinaryParseErrorKind::InvalidRefType(byte).into()),
+            0x70 => Some(RefType::Func),
+            0x6F => Some(RefType::Extern),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
Uses similar patterns as the text parer, with a tracer instance collection messages that get placed into errors when they are created.