### PR TITLE
Fix binary LEB128 malformed tests

### DIFF
--- a/tests-integration/tests/leb128.rs
+++ b/tests-integration/tests/leb128.rs
@@ -97,7 +97,7 @@ fn test_leb128_u64() -> Result<()> {
 
 #[test]
 fn test_leb128_i32() {
-    let data: Vec<u8> = vec![0xFF, 0xFF, 0xFF, 0xFF, 0x0F];
+    let data: Vec<u8> = vec![0xFF, 0xFF, 0xFF, 0xFF, 0x7F];
     let res = data.as_slice().read_i32_leb_128().unwrap();
     assert_eq!(res, -1);
 
@@ -120,7 +120,7 @@ fn test_leb128_i64() {
     let res = data.as_slice().read_i64_leb_128().unwrap();
     assert_eq!(res, 0x7FFFFFFFFFFFFFFF);
 
-    let data: Vec<u8> = vec![0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01];
+    let data: Vec<u8> = vec![0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x7F];
     let res = data.as_slice().read_i64_leb_128().unwrap();
     assert_eq!(res, -0x8000000000000000);
 
@@ -128,7 +128,7 @@ fn test_leb128_i64() {
     let res = data.as_slice().read_i64_leb_128().unwrap();
     assert_eq!(res, -128);
 
-    let data: Vec<u8> = vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01];
+    let data: Vec<u8> = vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F];
     let res = data.as_slice().read_i64_leb_128().unwrap();
     assert_eq!(res, -1);
 

--- a/tests-spec/tests/main.rs
+++ b/tests-spec/tests/main.rs
@@ -32,10 +32,7 @@ macro_rules! indices {
 
 spectest!(r#address);
 spectest!(r#align);
-spectest!(r#binary_x_leb128; [nomalformed!(
-    "integer representation too long",
-    "integer too large"
-)]);
+spectest!(r#binary_x_leb128);
 spectest!(r#binary; [nomalformed!(
     "magic header not detected",
     "unexpected end",
@@ -54,7 +51,6 @@ spectest!(r#binary; [nomalformed!(
     "malformed reference type",
     "length out of bounds",
     "malformed import kind",
-    "integer representation too long",
     "unexpected content after last section"
 )]);
 spectest!(r#block; [nomalformed!("inline function type", "mismatching label")]);

--- a/wrausmt-format/src/binary/custom.rs
+++ b/wrausmt-format/src/binary/custom.rs
@@ -2,14 +2,19 @@ use {
     super::{error::Result, BinaryParser},
     crate::{binary::error::ParseResult, pctx},
     std::io::Read,
+    wrausmt_runtime::syntax,
 };
 
 /// Read a custom section, which is interpreted as a simple vec(bytes)
 impl<R: Read> BinaryParser<R> {
-    pub(in crate::binary) fn read_custom_section(&mut self) -> Result<Box<[u8]>> {
+    pub(in crate::binary) fn read_custom_section(&mut self) -> Result<syntax::CustomField> {
         pctx!(self, "read custom section");
+        let name = self.read_name()?;
         let mut section: Vec<u8> = vec![];
         self.read_to_end(&mut section).result(self)?;
-        Ok(section.into_boxed_slice())
+        Ok(syntax::CustomField {
+            name,
+            content: section.into_boxed_slice(),
+        })
     }
 }

--- a/wrausmt-format/src/binary/error.rs
+++ b/wrausmt-format/src/binary/error.rs
@@ -24,13 +24,14 @@ pub enum BinaryParseErrorKind {
     InvalidRefType(u8),
     InvalidExportType(u8),
     InvalidImportType(u8),
+    InvalidFuncType(u8),
     ExtraSectionBytes(u64),
     TooManyLocals,
 }
 
 #[derive(Debug)]
 pub struct BinaryParseError {
-    kind:     BinaryParseErrorKind,
+    pub kind: BinaryParseErrorKind,
     msgs:     Vec<String>,
     location: usize,
 }

--- a/wrausmt-format/src/binary/section.rs
+++ b/wrausmt-format/src/binary/section.rs
@@ -54,7 +54,7 @@ impl<R: Read> BinaryParser<R> {
 pub enum Section {
     Eof,
     Skip,
-    Custom(Box<[u8]>),
+    Custom(syntax::CustomField),
     Types(Vec<syntax::TypeField>),
     Imports(Vec<syntax::ImportField<syntax::Resolved>>),
     Funcs(Vec<syntax::Index<syntax::Resolved, syntax::TypeIndex>>),

--- a/wrausmt-format/src/text/resolve.rs
+++ b/wrausmt-format/src/text/resolve.rs
@@ -427,6 +427,7 @@ pub trait ResolveModule {
 impl ResolveModule for Module<Unresolved> {
     fn resolve(mut self, mi: ModuleIdentifiers) -> Result<Module<Resolved>> {
         let rc = ResolutionContext::new(mi);
+        let customs = self.customs;
         let types = &mut self.types;
         let funcs = resolve_all!(self.funcs, rc, types)?;
         let imports = resolve_all!(self.imports, rc, types)?;
@@ -438,6 +439,7 @@ impl ResolveModule for Module<Unresolved> {
 
         Ok(Module {
             id: self.id,
+            customs,
             types: self.types,
             funcs,
             tables: self.tables,

--- a/wrausmt-runtime/src/syntax/mod.rs
+++ b/wrausmt-runtime/src/syntax/mod.rs
@@ -195,6 +195,7 @@ impl<R: ResolvedState, S: IndexSpace> fmt::Debug for Index<R, S> {
 /// [Spec]: https://webassembly.github.io/spec/core/text/modules.html#modules
 pub struct Module<R: ResolvedState> {
     pub id:       Option<Id>,
+    pub customs:  Vec<CustomField>,
     pub types:    Vec<TypeField>,
     pub funcs:    Vec<FuncField<R>>,
     pub tables:   Vec<TableField>,
@@ -328,6 +329,14 @@ impl std::fmt::Debug for FResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "(result {:?})", self.valuetype)
     }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+// customsec := section_0(custom)
+// custom := name byte*
+pub struct CustomField {
+    pub name:    String,
+    pub content: Box<[u8]>,
 }
 
 // type := (type id? <functype>)


### PR DESCRIPTION
* Properly parse custom sections to trigger the malformed tests
* Fix type byte parsing, which should be LEB128 7-bit signed.
* Fix sign-extending and sign detection when parsing LEB128
* Simplify the type interpretation code (traits are overkill)
