### PR TITLE
Simplify bounded section checking logic

### DIFF
--- a/wrausmt-format/src/binary/custom.rs
+++ b/wrausmt-format/src/binary/custom.rs
@@ -1,20 +1,29 @@
 use {
-    super::{error::Result, BinaryParser},
-    crate::{binary::error::ParseResult, pctx},
+    super::{error::Result, BinaryParser, ParserReader},
+    crate::{
+        binary::{error::ParseResult, read_with_location::Location},
+        pctx,
+    },
     std::io::Read,
     wrausmt_runtime::syntax,
 };
 
 /// Read a custom section, which is interpreted as a simple vec(bytes)
-impl<R: Read> BinaryParser<R> {
-    pub(in crate::binary) fn read_custom_section(&mut self) -> Result<syntax::CustomField> {
+impl<R: ParserReader> BinaryParser<R> {
+    pub(in crate::binary) fn read_custom_section(
+        &mut self,
+        expected_section_size: usize,
+    ) -> Result<syntax::CustomField> {
         pctx!(self, "read custom section");
+        let name_start = self.location();
         let name = self.read_name()?;
-        let mut section: Vec<u8> = vec![];
-        self.read_to_end(&mut section).result(self)?;
+        let name_size = self.location() - name_start;
+        let expected_content_size = expected_section_size - name_size;
+        let mut content: Vec<u8> = vec![0; expected_content_size];
+        self.read_exact(&mut content).result(self)?;
         Ok(syntax::CustomField {
             name,
-            content: section.into_boxed_slice(),
+            content: content.into_boxed_slice(),
         })
     }
 }

--- a/wrausmt-format/src/binary/data.rs
+++ b/wrausmt-format/src/binary/data.rs
@@ -1,12 +1,11 @@
 use {
-    super::{error::Result, leb128::ReadLeb128, BinaryParser},
+    super::{error::Result, leb128::ReadLeb128, BinaryParser, ParserReader},
     crate::{binary::error::ParseResult, pctx},
-    std::io::Read,
     wrausmt_runtime::syntax::{DataField, DataInit, Index, Resolved},
 };
 
 /// Read the tables section of a binary module from a std::io::Read.
-impl<R: Read> BinaryParser<R> {
+impl<R: ParserReader> BinaryParser<R> {
     /// Read a funcs section. This is just a vec(TypeIndex).
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.

--- a/wrausmt-format/src/binary/elems.rs
+++ b/wrausmt-format/src/binary/elems.rs
@@ -1,10 +1,9 @@
 use {
-    super::{error::Result, leb128::ReadLeb128, BinaryParser},
+    super::{error::Result, leb128::ReadLeb128, BinaryParser, ParserReader},
     crate::{
         binary::error::{BinaryParseErrorKind, ParseResult},
         pctx,
     },
-    std::io::Read,
     wrausmt_runtime::syntax::{
         self, types::RefType, ElemField, ElemList, Expr, FuncIndex, Id, Index, Instruction,
         ModeEntry, Opcode, Resolved, TablePosition, TableUse,
@@ -49,7 +48,7 @@ impl ElemVariant {
 }
 
 /// Read the tables section of a binary module from a std::io::Read.
-impl<R: Read> BinaryParser<R> {
+impl<R: ParserReader> BinaryParser<R> {
     pub fn read_elems_section(&mut self) -> Result<Vec<ElemField<Resolved>>> {
         pctx!(self, "read elems section");
         self.read_vec(|_, s| s.read_elem())

--- a/wrausmt-format/src/binary/exports.rs
+++ b/wrausmt-format/src/binary/exports.rs
@@ -1,16 +1,15 @@
 use {
     super::{
         error::{BinaryParseErrorKind, Result},
-        BinaryParser,
+        BinaryParser, ParserReader,
     },
     crate::pctx,
-    std::io::Read,
     wrausmt_runtime::syntax::{ExportDesc, ExportField, Resolved},
 };
 
 /// A trait to allow parsing of an exports section from something implementing
 /// std::io::Read.
-impl<R: Read> BinaryParser<R> {
+impl<R: ParserReader> BinaryParser<R> {
     /// Read the exports section of a module.
     /// exportsec := section vec(export)
     /// export := nm:name d:exportdesc

--- a/wrausmt-format/src/binary/funcs.rs
+++ b/wrausmt-format/src/binary/funcs.rs
@@ -1,12 +1,11 @@
 use {
-    super::{error::Result, BinaryParser},
+    super::{error::Result, BinaryParser, ParserReader},
     crate::pctx,
-    std::io::Read,
     wrausmt_runtime::syntax::{Index, Resolved, TypeIndex},
 };
 
 /// Read the funcs section of a binary module from a std::io::Read.
-impl<R: Read> BinaryParser<R> {
+impl<R: ParserReader> BinaryParser<R> {
     /// Read a funcs section. This is just a vec(TypeIndex).
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.

--- a/wrausmt-format/src/binary/globals.rs
+++ b/wrausmt-format/src/binary/globals.rs
@@ -1,12 +1,11 @@
 use {
-    super::{error::Result, BinaryParser},
+    super::{error::Result, BinaryParser, ParserReader},
     crate::pctx,
-    std::io::Read,
     wrausmt_runtime::syntax::{GlobalField, Resolved},
 };
 
 /// Read the tables section of a binary module from a std::io::Read.
-impl<R: Read> BinaryParser<R> {
+impl<R: ParserReader> BinaryParser<R> {
     /// Read a funcs section. This is just a vec(TypeIndex).
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.

--- a/wrausmt-format/src/binary/imports.rs
+++ b/wrausmt-format/src/binary/imports.rs
@@ -1,16 +1,15 @@
 use {
     super::{
         error::{BinaryParseErrorKind, Result},
-        BinaryParser,
+        BinaryParser, ParserReader,
     },
     crate::pctx,
-    std::io::Read,
     wrausmt_runtime::syntax::{ImportDesc, ImportField, Resolved},
 };
 
 /// A trait to allow parsing of an imports section from something implementing
 /// std::io::Read.
-impl<R: Read> BinaryParser<R> {
+impl<R: ParserReader> BinaryParser<R> {
     /// Read the imports section of a module.
     /// importsec := section vec(import)
     /// import := modname:name nm:name d:exportdesc

--- a/wrausmt-format/src/binary/mems.rs
+++ b/wrausmt-format/src/binary/mems.rs
@@ -1,12 +1,11 @@
 use {
-    super::{error::Result, BinaryParser},
+    super::{error::Result, BinaryParser, ParserReader},
     crate::pctx,
-    std::io::Read,
     wrausmt_runtime::syntax::MemoryField,
 };
 
 /// Read the tables section of a binary module from a std::io::Read.
-impl<R: Read> BinaryParser<R> {
+impl<R: ParserReader> BinaryParser<R> {
     /// Read a funcs section. This is just a vec(TypeIndex).
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.

--- a/wrausmt-format/src/binary/read_with_location.rs
+++ b/wrausmt-format/src/binary/read_with_location.rs
@@ -6,6 +6,10 @@ pub struct ReadWithLocation<R> {
     location: usize,
 }
 
+pub trait Location {
+    fn location(&self) -> usize;
+}
+
 impl<R> ReadWithLocation<R> {
     pub fn new(r: R) -> Self {
         ReadWithLocation {
@@ -24,5 +28,11 @@ impl<T: Read> Read for ReadWithLocation<T> {
         let cnt = self.inner.read(buf)?;
         self.location += cnt;
         Ok(cnt)
+    }
+}
+
+impl<T: Read> Location for ReadWithLocation<T> {
+    fn location(&self) -> usize {
+        self.location()
     }
 }

--- a/wrausmt-format/src/binary/start.rs
+++ b/wrausmt-format/src/binary/start.rs
@@ -1,12 +1,11 @@
 use {
-    super::{error::Result, BinaryParser},
+    super::{error::Result, BinaryParser, ParserReader},
     crate::pctx,
-    std::io::Read,
     wrausmt_runtime::syntax::{Resolved, StartField},
 };
 
 /// Read the tables section of a binary module from a std::io::Read.
-impl<R: Read> BinaryParser<R> {
+impl<R: ParserReader> BinaryParser<R> {
     /// Read a funcs section. This is just a vec(TypeIndex).
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.

--- a/wrausmt-format/src/binary/tables.rs
+++ b/wrausmt-format/src/binary/tables.rs
@@ -1,12 +1,11 @@
 use {
-    super::{error::Result, BinaryParser},
+    super::{error::Result, BinaryParser, ParserReader},
     crate::pctx,
-    std::io::Read,
     wrausmt_runtime::syntax::TableField,
 };
 
 /// Read the tables section of a binary module from a std::io::Read.
-impl<R: Read> BinaryParser<R> {
+impl<R: ParserReader> BinaryParser<R> {
     /// Read a funcs section. This is just a vec(TypeIndex).
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.

--- a/wrausmt-format/src/binary/types.rs
+++ b/wrausmt-format/src/binary/types.rs
@@ -1,17 +1,16 @@
 use {
-    super::{error::Result, leb128::ReadLeb128, BinaryParser},
+    super::{error::Result, leb128::ReadLeb128, BinaryParser, ParserReader},
     crate::{
         binary::error::{BinaryParseErrorKind, ParseResult},
         pctx,
     },
-    std::io::Read,
     wrausmt_runtime::syntax::{
         types::{GlobalType, Limits, MemType, TableType, ValueType},
         FParam, FResult, FunctionType, Resolved, TypeField, TypeUse,
     },
 };
 
-impl<R: Read> BinaryParser<R> {
+impl<R: ParserReader> BinaryParser<R> {
     pub fn read_types_section(&mut self) -> Result<Vec<TypeField>> {
         pctx!(self, "read types section");
         self.read_vec(|_, s| {

--- a/wrausmt-format/src/binary/values.rs
+++ b/wrausmt-format/src/binary/values.rs
@@ -2,7 +2,7 @@ use {
     super::{
         error::{BinaryParseErrorKind, Result},
         leb128::ReadLeb128,
-        BinaryParser,
+        BinaryParser, ParserReader,
     },
     crate::{binary::error::ParseResult, pctx},
     std::io::Read,
@@ -12,7 +12,7 @@ use {
     },
 };
 
-impl<R: Read> BinaryParser<R> {
+impl<R: ParserReader> BinaryParser<R> {
     pub(in crate::binary) fn read_magic(&mut self) -> Result<()> {
         pctx!(self, "read magic");
         let mut buf = [0u8; 4];


### PR DESCRIPTION
No more wrapped "Take" readers; just check the size consumed and report an
error accordingly
