### PR TITLE
Some error cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,4 +47,5 @@ name = "wrausmt-runtime"
 version = "0.1.0"
 dependencies = [
  "codegen",
+ "wrausmt-common",
 ]

--- a/tests-spec/src/format/mod.rs
+++ b/tests-spec/src/format/mod.rs
@@ -2,10 +2,7 @@ use {
     std::io::Read,
     wrausmt_format::text::{
         location::Location,
-        parse::{
-            error::{Result, WithMsg},
-            pctx, Parser,
-        },
+        parse::{error::Result, pctx, Parser},
         string::WasmString,
         token::Token,
     },
@@ -136,7 +133,7 @@ impl<R: Read> SpecParser for Parser<R> {
             return Ok(None);
         }
 
-        let modname = self.expect_string().msg("parsing modname in register")?;
+        let modname = self.expect_string()?;
 
         let id = self.try_id()?;
 
@@ -169,7 +166,7 @@ impl<R: Read> SpecParser for Parser<R> {
 
         let modname = self.try_id()?;
 
-        let name = self.expect_string().msg("name")?;
+        let name = self.expect_string()?;
 
         let params = self.zero_or_more(Self::try_const)?;
 
@@ -190,7 +187,7 @@ impl<R: Read> SpecParser for Parser<R> {
 
         let modname = self.try_id()?;
 
-        let name = self.expect_string().msg("name")?;
+        let name = self.expect_string()?;
 
         self.expect_close()?;
 
@@ -214,19 +211,19 @@ impl<R: Read> SpecParser for Parser<R> {
         pctx!(self, "try meta cmd");
         if self.try_expr_start("script")? {
             let id = self.try_id()?;
-            let script = self.expect_string().msg("script")?;
+            let script = self.expect_string()?;
             self.expect_close()?;
             return Ok(Some(Cmd::Meta(Meta::Script { id, script })));
         }
         if self.try_expr_start("input")? {
             let id = self.try_id()?;
-            let file = self.expect_string().msg("input")?;
+            let file = self.expect_string()?;
             self.expect_close()?;
             return Ok(Some(Cmd::Meta(Meta::Input { id, file })));
         }
         if self.try_expr_start("output")? {
             let id = self.try_id()?;
-            let file = self.expect_string().msg("output")?;
+            let file = self.expect_string()?;
             self.expect_close()?;
             return Ok(Some(Cmd::Meta(Meta::Output { id, file })));
         }
@@ -256,7 +253,7 @@ impl<R: Read> SpecParser for Parser<R> {
         }
 
         let action = self.expect_action()?;
-        let failure = self.expect_string().msg("failure")?;
+        let failure = self.expect_string()?;
         self.expect_close()?;
 
         Ok(Some(Assertion::Exhaustion { action, failure }))
@@ -293,7 +290,7 @@ impl<R: Read> SpecParser for Parser<R> {
 
         let module = self.expect_spec_module()?;
 
-        let failure = self.expect_string().msg("failure")?;
+        let failure = self.expect_string()?;
 
         self.expect_close()?;
 
@@ -308,7 +305,7 @@ impl<R: Read> SpecParser for Parser<R> {
 
         let module = self.expect_spec_module()?;
 
-        let failure = self.expect_string().msg("failure")?;
+        let failure = self.expect_string()?;
 
         self.expect_close()?;
 

--- a/tests-spec/src/runner.rs
+++ b/tests-spec/src/runner.rs
@@ -193,8 +193,8 @@ impl SpecTestRunner {
                     }
                 }
                 ActionResult::NumPat(NumPat::NaNPat(nanpat)) => {
-                    let resultnum = match result.as_num() {
-                        Some(n) => n,
+                    let resultnum = match result {
+                        Value::Num(n) => n,
                         _ => return Err(TestFailureError::ResultMismatch { result, expect }),
                     };
                     if !nanpat.accepts(resultnum) {

--- a/wrausmt-common/src/lib.rs
+++ b/wrausmt-common/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod tracer;
+pub mod true_or;

--- a/wrausmt-common/src/true_or.rs
+++ b/wrausmt-common/src/true_or.rs
@@ -1,0 +1,22 @@
+pub trait TrueOr {
+    fn true_or<E>(&self, err: E) -> std::result::Result<(), E>;
+    fn true_or_else<E, F: Fn() -> E>(&self, err: F) -> std::result::Result<(), E>;
+}
+
+impl TrueOr for bool {
+    fn true_or_else<E, F: Fn() -> E>(&self, err: F) -> std::result::Result<(), E> {
+        if *self {
+            Ok(())
+        } else {
+            Err(err())
+        }
+    }
+
+    fn true_or<E>(&self, err: E) -> std::result::Result<(), E> {
+        if *self {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    }
+}

--- a/wrausmt-format/src/binary/data.rs
+++ b/wrausmt-format/src/binary/data.rs
@@ -16,8 +16,7 @@ impl<R: ParserReader> BinaryParser<R> {
 
     pub(in crate::binary) fn read_data_count_section(&mut self) -> Result<u32> {
         pctx!(self, "read data count section");
-        let r = self.read_u32_leb_128().result(self)?;
-        Ok(r)
+        self.read_u32_leb_128().result(self)
     }
 
     fn read_data_field(&mut self) -> Result<DataField<Resolved>> {

--- a/wrausmt-format/src/binary/elems.rs
+++ b/wrausmt-format/src/binary/elems.rs
@@ -4,6 +4,7 @@ use {
         binary::error::{BinaryParseErrorKind, ParseResult},
         pctx,
     },
+    wrausmt_common::true_or::TrueOr,
     wrausmt_runtime::syntax::{
         self, types::RefType, ElemField, ElemList, Expr, FuncIndex, Id, Index, Instruction,
         ModeEntry, Opcode, Resolved, TablePosition, TableUse,
@@ -58,9 +59,8 @@ impl<R: ParserReader> BinaryParser<R> {
         pctx!(self, "read elem kind");
         // read elemkind type, always 0
         let elemkind = self.read_byte()?;
-        if elemkind != 0 {
-            return Err(self.err(BinaryParseErrorKind::InvalidElemKind(elemkind)));
-        }
+        (elemkind == 0)
+            .true_or_else(|| self.err(BinaryParseErrorKind::InvalidElemKind(elemkind)))?;
         Ok(RefType::Func)
     }
 

--- a/wrausmt-format/src/text/lex/error.rs
+++ b/wrausmt-format/src/text/lex/error.rs
@@ -26,27 +26,6 @@ impl std::fmt::Display for LexError {
 
 impl std::error::Error for LexError {}
 
-impl WithContext<LexError> for LexError {
-    fn ctx(self, ctx: &str) -> Self {
-        match self {
-            LexError::WithContext(mut ctxs, e) => {
-                ctxs.push(ctx.to_owned());
-                LexError::WithContext(ctxs, e)
-            }
-            e => LexError::WithContext(vec![ctx.to_owned()], Box::new(e)),
-        }
-    }
-}
-
-impl<T, E: Into<LexError>> WithContext<Result<T>> for std::result::Result<T, E> {
-    fn ctx(self, ctx: &str) -> Result<T> {
-        match self {
-            Ok(v) => Ok(v),
-            Err(e) => Err(e.into().ctx(ctx)),
-        }
-    }
-}
-
 impl From<std::io::Error> for LexError {
     fn from(e: std::io::Error) -> Self {
         LexError::IoError(e)

--- a/wrausmt-format/src/text/module_builder.rs
+++ b/wrausmt-format/src/text/module_builder.rs
@@ -1,6 +1,7 @@
 use {
     super::resolve::{ResolveError, ResolveModule, Result},
     std::collections::HashMap,
+    wrausmt_common::true_or::TrueOr,
     wrausmt_runtime::syntax::{
         DataField, ElemField, ExportDesc, ExportField, FuncField, GlobalField, Id, ImportDesc,
         ImportField, Index, MemoryField, Module, Resolved, StartField, TableField, TypeField,
@@ -133,15 +134,11 @@ impl ModuleBuilder {
     }
 
     pub fn add_importfield(&mut self, f: ImportField<Unresolved>) -> Result<()> {
-        if !self.module.funcs.is_empty() {
-            return Err(ResolveError::ImportAfterFunction);
-        } else if !self.module.globals.is_empty() {
-            return Err(ResolveError::ImportAfterGlobal);
-        } else if !self.module.memories.is_empty() {
-            return Err(ResolveError::ImportAfterMemory);
-        } else if !self.module.tables.is_empty() {
-            return Err(ResolveError::ImportAfterTable);
-        }
+        (self.module.funcs.is_empty()).true_or(ResolveError::ImportAfterFunction)?;
+        (self.module.globals.is_empty()).true_or(ResolveError::ImportAfterGlobal)?;
+        (self.module.memories.is_empty()).true_or(ResolveError::ImportAfterMemory)?;
+        (self.module.tables.is_empty()).true_or(ResolveError::ImportAfterTable)?;
+
         // Imports contribute to index counts in their corresponding
         // space, and must appear before any declarations of that type
         // in the module, so we track their counts of each type in order

--- a/wrausmt-format/src/text/parse/error.rs
+++ b/wrausmt-format/src/text/parse/error.rs
@@ -69,18 +69,6 @@ impl std::fmt::Display for ParseErrorKind {
 pub type Result<T> = std::result::Result<T, ParseError>;
 pub type KindResult<T> = std::result::Result<T, ParseErrorKind>;
 
-pub trait WithMsg {
-    fn msg(self, msg: impl Into<String>) -> Self;
-}
-impl<T> WithMsg for Result<T> {
-    fn msg(mut self, msg: impl Into<String>) -> Self {
-        if let Err(e) = &mut self {
-            e.msgs.push(msg.into())
-        }
-        self
-    }
-}
-
 impl From<ResolveError> for ParseErrorKind {
     fn from(re: ResolveError) -> Self {
         ParseErrorKind::ResolveError(re)

--- a/wrausmt-format/src/text/parse/instruction.rs
+++ b/wrausmt-format/src/text/parse/instruction.rs
@@ -76,7 +76,7 @@ impl<R: Read> Parser<R> {
                         let tabidx = self.try_index()?;
                         let elemidx = self.try_index()?;
                         let (tabidx, elemidx) = match (tabidx, elemidx) {
-                            (None, None) => return Err(self.unexpected_token("elem idx")),
+                            (None, None) => Err(self.unexpected_token("elem idx"))?,
                             (None, Some(elemidx)) => (Index::unnamed(0), elemidx),
                             (Some(tabidx), None) => (Index::unnamed(0), tabidx.convert()),
                             (Some(tabidx), Some(elemidx)) => (tabidx, elemidx),
@@ -227,7 +227,7 @@ impl<R: Read> Parser<R> {
             self.expect_close()?;
             Expr { instr }
         } else {
-            return Err(self.unexpected_token("then"));
+            Err(self.unexpected_token("then"))?
         };
         let elexpr = if self.try_expr_start("else")? {
             let instr = self.zero_or_more_groups(Self::try_instruction)?;

--- a/wrausmt-format/src/text/parse/module.rs
+++ b/wrausmt-format/src/text/parse/module.rs
@@ -1,6 +1,6 @@
 use {
     super::{
-        error::{ParseErrorKind, Result, WithMsg},
+        error::{ParseErrorKind, Result},
         pctx, ParseResult, Parser,
     },
     crate::text::{module_builder::ModuleBuilder, token::Token},
@@ -348,8 +348,8 @@ impl<R: Read> Parser<R> {
             return Ok(None);
         }
 
-        let modname = self.expect_string().msg("import modname")?;
-        let name = self.expect_string().msg("import name")?;
+        let modname = self.expect_string()?;
+        let name = self.expect_string()?;
 
         let (id, desc) = self.expect_importdesc()?;
 
@@ -417,7 +417,7 @@ impl<R: Read> Parser<R> {
             return Ok(None);
         }
 
-        let name = self.expect_string().msg("expected name")?;
+        let name = self.expect_string()?;
 
         let exportdesc = self.expect_exportdesc()?;
 
@@ -595,7 +595,7 @@ impl<R: Read> Parser<R> {
             return Ok(None);
         }
 
-        let data = self.expect_string().msg("data")?;
+        let data = self.expect_string()?;
 
         self.expect_close()?;
 
@@ -610,8 +610,8 @@ impl<R: Read> Parser<R> {
             return Ok(None);
         }
 
-        let modname = self.expect_string().msg("modname")?;
-        let name = self.expect_string().msg("name")?;
+        let modname = self.expect_string()?;
+        let name = self.expect_string()?;
 
         self.expect_close()?;
 

--- a/wrausmt-runtime/Cargo.toml
+++ b/wrausmt-runtime/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 "codegen" = { workspace = true }
+wrausmt-common = { workspace = true }
 
 [build-dependencies]
 "codegen" = { workspace = true }

--- a/wrausmt-runtime/src/instructions/mod.rs
+++ b/wrausmt-runtime/src/instructions/mod.rs
@@ -10,10 +10,7 @@ use {
     },
     crate::{
         impl_bug,
-        runtime::{
-            error::{Result, WithContext},
-            exec::ExecutionContext,
-        },
+        runtime::{error::Result, exec::ExecutionContext},
         syntax::{Id, Opcode},
     },
 };
@@ -93,12 +90,12 @@ pub type ExecFn = fn(ec: &mut ExecutionContext) -> Result<()>;
 /// This function appears in the lookup table for opcodes that don't have a
 /// corresponding operation in the specification.
 pub fn bad(_ec: &mut ExecutionContext) -> Result<()> {
-    Err(impl_bug!("unknown opcode"))
+    Err(impl_bug!("unknown opcode"))?
 }
 
 /// This function is used to mark not-yet-implemented instructions in the table.
 pub fn unimpl(_ec: &mut ExecutionContext) -> Result<()> {
-    Err(impl_bug!("not yet implemented"))
+    Err(impl_bug!("not yet implemented"))?
 }
 
 pub const BAD_INSTRUCTION: InstructionData = InstructionData {
@@ -114,8 +111,8 @@ pub fn exec_method(opcode: Opcode, ec: &mut ExecutionContext) -> Result<()> {
         Opcode::Normal(o) => EXEC_TABLE.get(o as usize),
     };
     match exec_fn {
-        Some(ef) => ef(ec).ctx(|| format!("for op {:?} - {:?}", opcode, instruction_data(&opcode))),
-        None => Err(impl_bug!("Exec table short")),
+        Some(ef) => ef(ec),
+        None => Err(impl_bug!("Exec table short"))?,
     }
 }
 

--- a/wrausmt-runtime/src/runtime/compile.rs
+++ b/wrausmt-runtime/src/runtime/compile.rs
@@ -222,7 +222,5 @@ pub fn compile_function_body(func: &syntax::FuncField<Resolved>) -> Box<[u8]> {
     out.emit_expr(&func.body);
     out.emit_opcode(END_OPCODE);
 
-    // ???
-    // profit!
     out.into_boxed_slice()
 }

--- a/wrausmt-runtime/src/runtime/instance/function_instance.rs
+++ b/wrausmt-runtime/src/runtime/instance/function_instance.rs
@@ -9,6 +9,7 @@ use {
         syntax::types::{FunctionType, ValueType},
     },
     std::rc::Rc,
+    wrausmt_common::true_or::TrueOr,
 };
 
 /// A function instance is the runtime representation of a function.
@@ -52,13 +53,10 @@ struct HostFunc {
 impl FunctionInstance {
     pub fn validate_args(&self, args: &[Value]) -> Result<()> {
         let params_arity = self.functype.params.len();
-        if params_arity != args.len() {
-            return Err(RuntimeErrorKind::ArgumentCountError {
-                expected: params_arity,
-                got:      args.len(),
-            }
-            .error());
-        }
+        (params_arity == args.len()).true_or_else(|| RuntimeErrorKind::ArgumentCountError {
+            expected: params_arity,
+            got:      args.len(),
+        })?;
         Ok(())
     }
 

--- a/wrausmt-runtime/src/runtime/instance/module_instance.rs
+++ b/wrausmt-runtime/src/runtime/instance/module_instance.rs
@@ -61,9 +61,7 @@ impl ModuleInstance {
     }
 
     pub fn resolve(&self, name: &str) -> Option<&ExportInstance> {
-        let found = self.exports.iter().find(|e| e.name == name);
-
-        found
+        self.exports.iter().find(|e| e.name == name)
     }
 }
 

--- a/wrausmt-runtime/src/runtime/mod.rs
+++ b/wrausmt-runtime/src/runtime/mod.rs
@@ -103,7 +103,7 @@ impl Runtime {
                 name: _,
                 addr: ExternalVal::Func(idx),
             }) => Ok(*idx),
-            _ => Err(RuntimeErrorKind::MethodNotFound(name.to_owned()).error()),
+            _ => Err(RuntimeErrorKind::MethodNotFound(name.to_owned())),
         }?;
 
         self.logger
@@ -146,15 +146,15 @@ impl Runtime {
         // Since we don't do validation yet, do some checking here to make sure things
         // seem ok.
         if let Ok(v) = self.stack.pop_value() {
-            return Err(impl_bug!("values still on stack {:?}", v));
+            Err(impl_bug!("values still on stack {:?}", v))?;
         }
 
         if let Ok(l) = self.stack.peek_label() {
-            return Err(impl_bug!("labels still on stack {:?}", l));
+            Err(impl_bug!("labels still on stack {:?}", l))?;
         }
 
         if self.stack.activation_depth() != 0 {
-            return Err(impl_bug!("frames still on stack"));
+            Err(impl_bug!("frames still on stack"))?;
         }
         Ok(results)
     }
@@ -164,9 +164,9 @@ impl Runtime {
             Some(ExportInstance {
                 name: _,
                 addr: ExternalVal::Global(idx),
-            }) => Ok(*idx),
-            _ => Err(RuntimeErrorKind::MethodNotFound(name.to_owned()).error()),
-        }?;
+            }) => *idx,
+            _ => Err(RuntimeErrorKind::MethodNotFound(name.to_owned()))?,
+        };
 
         self.logger
             .log(Tag::Host, || format!("calling {} at {}", name, globaladdr));

--- a/wrausmt-runtime/src/runtime/values.rs
+++ b/wrausmt-runtime/src/runtime/values.rs
@@ -80,10 +80,6 @@ impl Value {
         }
     }
 
-    pub fn is(&self, vt: ValueType) -> bool {
-        self.valtype() == vt
-    }
-
     pub fn as_num(&self) -> Option<Num> {
         match self {
             Value::Num(n) => Some(*n),
@@ -178,7 +174,7 @@ macro_rules! froms {
                         "couldn't convert {:?} {}",
                         val,
                         stringify!($name)
-                    )),
+                    ))?,
                 }
             }
         }
@@ -212,7 +208,7 @@ impl TryFrom<Value> for Ref {
     fn try_from(v: Value) -> Result<Ref, Self::Error> {
         match v {
             Value::Ref(r) => Ok(r),
-            _ => Err(impl_bug!("{:?} is not a ref", v)),
+            _ => Err(impl_bug!("{:?} is not a ref", v))?,
         }
     }
 }


### PR DESCRIPTION
* Introduce true_or/true_or_else pattern
* Remove unused/outdated error traits
* Use Ok(fallible()?) instead of let r = fallible()?; Ok(r);
* Consistently use Err()? for early error returns instead of return Err
