### PR TITLE
Clean up resolver code type usage, reduce cloning

### DIFF
--- a/wrausmt-format/src/text/module_builder.rs
+++ b/wrausmt-format/src/text/module_builder.rs
@@ -75,8 +75,7 @@ impl ModuleBuilder {
     }
 
     pub fn build(self) -> Result<Module<Resolved>> {
-        let mod_idents = self.module_identifiers;
-        self.module.resolve(mod_idents)
+        self.module.resolve(&self.module_identifiers)
     }
 
     pub fn tables(&self) -> u32 {


### PR DESCRIPTION
* Keep mutable type vector in ResolutionContext as reference
* Keep ModuleIdentifiers as reference
