### PR TITLE
Fix remaining malformed number tests

### DIFF
--- a/tests-integration/src/spec/error_mappings.rs
+++ b/tests-integration/src/spec/error_mappings.rs
@@ -71,6 +71,7 @@ fn matches_trap(failure: &str, trap: &TrapKind) -> bool {
 
 fn matches_bin_parse_error(failure: &str, bin_parse_err: &BinaryParseErrorKind) -> bool {
     match failure {
+        // TODO - clean up code to simplify to 1:1 mapping.
         "integer too large" => {
             matches!(
                 bin_parse_err,
@@ -80,9 +81,13 @@ fn matches_bin_parse_error(failure: &str, bin_parse_err: &BinaryParseErrorKind) 
         // TODO - remove the need for InvalidFuncType
         "integer representation too long" => matches!(
             bin_parse_err,
-            BinaryParseErrorKind::LEB128Error(LEB128Error::Unterminated(_))
+            BinaryParseErrorKind::InvalidBoolValue(_)
+                | BinaryParseErrorKind::LEB128Error(LEB128Error::Unterminated(_))
                 | BinaryParseErrorKind::InvalidFuncType(_)
         ),
+        "malformed mutability" => {
+            matches!(bin_parse_err, BinaryParseErrorKind::InvalidBoolValue(_))
+        }
         "magic header not detected" => {
             matches!(bin_parse_err, BinaryParseErrorKind::IncorrectMagic(_))
         }
@@ -147,7 +152,9 @@ fn matches_parse_error(failure: &str, parse_err: &ParseErrorKind) -> bool {
 
     match failure {
         "alignment" => matches!(parse_err, ParseErrorKind::InvalidAlignment(_)),
-        "i32 constant" => matches!(parse_err, ParseErrorKind::ParseIntError(_)),
+        "i32 constant" => matches!(parse_err, ParseErrorKind::ConstantOutOfRange),
+        "i32 constant out of range" => matches!(parse_err, ParseErrorKind::ConstantOutOfRange),
+        "constant out of range" => matches!(parse_err, ParseErrorKind::ConstantOutOfRange),
         "unknown label" => matches!(parse_err, ParseErrorKind::ResolveError(_)),
         "unexpected token" => matches!(
             parse_err,
@@ -162,7 +169,6 @@ fn matches_parse_error(failure: &str, parse_err: &ParseErrorKind) -> bool {
             ParseErrorKind::UnexpectedToken(_) | ParseErrorKind::UnrecognizedInstruction(_)
         ),
         "malformed UTF-8 encoding" => matches!(parse_err, ParseErrorKind::Utf8Error(_)),
-        "constant out of range" => matches!(parse_err, ParseErrorKind::InvalidNaN(_)),
 
         "mismatching label" => matches!(parse_err, ParseErrorKind::LabelMismatch(_, _)),
         _ => false,

--- a/tests-integration/tests/spec/mod.rs
+++ b/tests-integration/tests/spec/mod.rs
@@ -58,12 +58,6 @@ macro_rules! spectest {
     ($name:ident) => { spectest!($name; [RunSet::All]); };
 }
 
-macro_rules! nomalformed {
-    ($($failure:literal),*) => {
-        RunSet::ExcludeFailure(vec![$($failure.into()),*])
-    };
-}
-
 #[allow(unused_macros)]
 macro_rules! indices {
     ($($idx:literal),*) => {
@@ -83,7 +77,7 @@ spectest!(r#bulk);
 spectest!(r#call);
 spectest!(r#call_indirect);
 spectest!(r#comments);
-spectest!(r#const; [nomalformed!("unknown operator", "constant out of range")]);
+spectest!(r#const);
 spectest!(r#conversions);
 spectest!(r#custom);
 spectest!(r#data);
@@ -104,7 +98,7 @@ spectest!(r#float_misc);
 spectest!(r#forward);
 spectest!(r#func);
 spectest!(r#func_ptrs);
-spectest!(r#global; [nomalformed!("malformed mutability")]);
+spectest!(r#global);
 spectest!(r#i32);
 spectest!(r#i64);
 spectest!(r#if);
@@ -120,7 +114,7 @@ spectest!(r#local_get);
 spectest!(r#local_set);
 spectest!(r#local_tee);
 spectest!(r#loop);
-spectest!(r#memory; [nomalformed!("i32 constant out of range")]);
+spectest!(r#memory);
 spectest!(r#memory_copy);
 spectest!(r#memory_fill);
 spectest!(r#memory_grow);
@@ -129,7 +123,7 @@ spectest!(r#memory_redundancy);
 spectest!(r#memory_size);
 spectest!(r#memory_trap);
 spectest!(r#names);
-spectest!(r#nop; [indices!(0, 1,2)]);
+spectest!(r#nop);
 spectest!(r#obsolete_x_keywords);
 spectest!(r#ref_func);
 spectest!(r#ref_is_null);
@@ -142,7 +136,7 @@ spectest!(r#start);
 spectest!(r#store);
 spectest!(r#switch);
 spectest!(r#table_x_sub);
-spectest!(r#table; [nomalformed!("i32 constant out of range")]);
+spectest!(r#table);
 spectest!(r#table_copy);
 spectest!(r#table_fill);
 spectest!(r#table_get);

--- a/wrausmt-format/src/binary/values.rs
+++ b/wrausmt-format/src/binary/values.rs
@@ -58,10 +58,11 @@ impl<R: ParserReader> BinaryParser<R> {
     /// false).
     pub(in crate::binary) fn read_bool(&mut self) -> Result<bool> {
         pctx!(self, "read bool");
-        match self.read_i7_leb_128().result(self)? {
-            0 => Ok(false),
-            1 => Ok(true),
-            b => Err(self.err(BinaryParseErrorKind::InvalidBoolValue(b as u8))),
+        match self.read_byte() {
+            Ok(0) => Ok(false),
+            Ok(1) => Ok(true),
+            Ok(b) => Err(self.err(BinaryParseErrorKind::InvalidBoolValue(b))),
+            Err(e) => Err(e),
         }
     }
 

--- a/wrausmt-format/src/text/num.rs
+++ b/wrausmt-format/src/text/num.rs
@@ -122,22 +122,26 @@ pub fn maybe_number(idchars: &str) -> Option<NumToken> {
         cursor.advance_by(1);
     }
 
-    let mut exp = match cursor.cur() {
+    let exp_sign = match cursor.cur() {
         Some('+') => "+".to_string(),
         Some('-') => "-".to_string(),
         _ => String::new(),
     };
 
-    cursor.advance_by(exp.len());
+    cursor.advance_by(exp_sign.len());
 
-    exp += &cursor.consume_digit_group(Base::Dec);
+    let exp = &cursor.consume_digit_group(Base::Dec);
+
+    if have_exp && exp.is_empty() {
+        return None;
+    }
 
     if !cursor.is_empty() {
         return None;
     }
 
     if have_point || have_exp {
-        Some(NumToken::Float(sign, base, whole, frac, exp))
+        Some(NumToken::Float(sign, base, whole, frac, exp_sign + exp))
     } else {
         Some(NumToken::Integer(sign, base, whole))
     }


### PR DESCRIPTION
* Switch back to just reading a byte normally when reading a bool
* Fix number lexing issue that missed a few invalid cases (exp letter with no
  exp)
* Fix out of range NaN
* Fix extreme end float rounding case
