### PR TITLE
Compile & Validation refactor part 1: indicate compilation state in type

### DIFF
--- a/tests-integration/src/spec/format.rs
+++ b/tests-integration/src/spec/format.rs
@@ -11,7 +11,7 @@ use {
         syntax::{
             self as modulesyntax,
             types::{NumType, RefType},
-            Id, Resolved,
+            Id, Resolved, UncompiledExpr,
         },
     },
 };
@@ -489,7 +489,7 @@ pub struct CmdEntry {
 /// ```
 #[derive(Debug)]
 pub enum Module {
-    Module(modulesyntax::Module<Resolved>),
+    Module(modulesyntax::Module<Resolved, UncompiledExpr<Resolved>>),
     Binary(Option<Id>, Vec<WasmString>),
     Quote(Option<Id>, Vec<WasmString>),
 }

--- a/tests-integration/src/spec/spectest_module.rs
+++ b/tests-integration/src/spec/spectest_module.rs
@@ -4,7 +4,7 @@ use {
         self,
         types::{GlobalType, Limits, MemType, NumType, TableType, ValueType},
         FParam, FuncField, FunctionType, GlobalField, Instruction, MemoryField, Resolved,
-        TableField, TypeUse, Unresolved,
+        TableField, TypeUse, UncompiledExpr, Unresolved,
     },
 };
 
@@ -26,7 +26,7 @@ use {
 ///  (func (export "print_i32_f32") (param i32 f32))
 ///  (func (export "print_f64_f64") (param f64 f64))
 /// )
-pub fn make_spectest_module() -> Result<syntax::Module<Resolved>> {
+pub fn make_spectest_module() -> Result<syntax::Module<Resolved, UncompiledExpr<Resolved>>> {
     let mut builder = ModuleBuilder::default();
 
     builder.add_globalfield(GlobalField {
@@ -36,7 +36,7 @@ pub fn make_spectest_module() -> Result<syntax::Module<Resolved>> {
             mutable: false,
             valtype: ValueType::Num(NumType::I32),
         },
-        init:       syntax::Expr {
+        init:       syntax::UncompiledExpr {
             instr: vec![Instruction::i32const(666)],
         },
     })?;
@@ -48,7 +48,7 @@ pub fn make_spectest_module() -> Result<syntax::Module<Resolved>> {
             mutable: false,
             valtype: ValueType::Num(NumType::I64),
         },
-        init:       syntax::Expr {
+        init:       syntax::UncompiledExpr {
             instr: vec![Instruction::i64const(666u64)],
         },
     })?;
@@ -59,7 +59,7 @@ pub fn make_spectest_module() -> Result<syntax::Module<Resolved>> {
             mutable: false,
             valtype: ValueType::Num(NumType::F32),
         },
-        init:       syntax::Expr {
+        init:       syntax::UncompiledExpr {
             instr: vec![Instruction::f32const(666f32)],
         },
     })?;
@@ -71,7 +71,7 @@ pub fn make_spectest_module() -> Result<syntax::Module<Resolved>> {
             mutable: false,
             valtype: ValueType::Num(NumType::F64),
         },
-        init:       syntax::Expr {
+        init:       syntax::UncompiledExpr {
             instr: vec![Instruction::f64const(666f64)],
         },
     })?;
@@ -145,7 +145,10 @@ pub fn make_spectest_module() -> Result<syntax::Module<Resolved>> {
     builder.build()
 }
 
-fn mkfunc(name: impl Into<String>, params: Vec<FParam>) -> FuncField<Unresolved> {
+fn mkfunc(
+    name: impl Into<String>,
+    params: Vec<FParam>,
+) -> FuncField<Unresolved, UncompiledExpr<Unresolved>> {
     FuncField {
         exports: vec![name.into()],
         typeuse: TypeUse::AnonymousInline(FunctionType {

--- a/wrausmt-format/src/binary/data.rs
+++ b/wrausmt-format/src/binary/data.rs
@@ -1,7 +1,7 @@
 use {
     super::{error::Result, leb128::ReadLeb128, BinaryParser, ParserReader},
     crate::{binary::error::ParseResult, pctx},
-    wrausmt_runtime::syntax::{DataField, DataInit, Index, Resolved},
+    wrausmt_runtime::syntax::{DataField, DataInit, Index, Resolved, UncompiledExpr},
 };
 
 /// Read the tables section of a binary module from a std::io::Read.
@@ -9,7 +9,9 @@ impl<R: ParserReader> BinaryParser<R> {
     /// Read a funcs section. This is just a vec(TypeIndex).
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.
-    pub(in crate::binary) fn read_data_section(&mut self) -> Result<Vec<DataField<Resolved>>> {
+    pub(in crate::binary) fn read_data_section(
+        &mut self,
+    ) -> Result<Vec<DataField<Resolved, UncompiledExpr<Resolved>>>> {
         pctx!(self, "read data section");
         self.read_vec(|_, s| s.read_data_field())
     }
@@ -19,7 +21,7 @@ impl<R: ParserReader> BinaryParser<R> {
         self.read_u32_leb_128().result(self)
     }
 
-    fn read_data_field(&mut self) -> Result<DataField<Resolved>> {
+    fn read_data_field(&mut self) -> Result<DataField<Resolved, UncompiledExpr<Resolved>>> {
         pctx!(self, "read data field");
         let variants = self.read_u32_leb_128().result(self)?;
         let active = (variants & 0x01) == 0;

--- a/wrausmt-format/src/binary/globals.rs
+++ b/wrausmt-format/src/binary/globals.rs
@@ -1,7 +1,7 @@
 use {
     super::{error::Result, BinaryParser, ParserReader},
     crate::pctx,
-    wrausmt_runtime::syntax::{GlobalField, Resolved},
+    wrausmt_runtime::syntax::{GlobalField, Resolved, UncompiledExpr},
 };
 
 /// Read the tables section of a binary module from a std::io::Read.
@@ -9,12 +9,14 @@ impl<R: ParserReader> BinaryParser<R> {
     /// Read a funcs section. This is just a vec(TypeIndex).
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.
-    pub(in crate::binary) fn read_globals_section(&mut self) -> Result<Vec<GlobalField<Resolved>>> {
+    pub(in crate::binary) fn read_globals_section(
+        &mut self,
+    ) -> Result<Vec<GlobalField<UncompiledExpr<Resolved>>>> {
         pctx!(self, "read globals section");
         self.read_vec(|_, s| s.read_global_field())
     }
 
-    fn read_global_field(&mut self) -> Result<GlobalField<Resolved>> {
+    fn read_global_field(&mut self) -> Result<GlobalField<UncompiledExpr<Resolved>>> {
         pctx!(self, "read global field");
         Ok(GlobalField {
             id:         None,

--- a/wrausmt-format/src/binary/mod.rs
+++ b/wrausmt-format/src/binary/mod.rs
@@ -9,7 +9,7 @@ use {
         tracer::{TraceDropper, Tracer},
         true_or::TrueOr,
     },
-    wrausmt_runtime::syntax::TypeUse,
+    wrausmt_runtime::syntax::{TypeUse, UncompiledExpr},
 };
 
 pub mod error;
@@ -52,7 +52,7 @@ pub trait ParserReader: Read + Location {}
 impl<R: ParserReader> BinaryParser<R> {
     /// Inner parse method accepts a mutable module, so that the outer parse
     /// method can return partial module results (useful for debugging).
-    fn parse(&mut self) -> Result<Module<Resolved>> {
+    fn parse(&mut self) -> Result<Module<Resolved, UncompiledExpr<Resolved>>> {
         let mut module = Module::default();
 
         self.read_magic()
@@ -145,7 +145,7 @@ impl<R: ParserReader> BinaryParser<R> {
 
     fn resolve_functypes(
         &mut self,
-        funcs: &mut [FuncField<Resolved>],
+        funcs: &mut [FuncField<Resolved, UncompiledExpr<Resolved>>],
         functypes: &[Index<Resolved, TypeIndex>],
     ) -> Result<()> {
         // In a valid module, we will have parsed the func types section already, so
@@ -209,7 +209,7 @@ impl<T: ParserReader> ParserReader for BinaryParser<T> {}
 /// Attempt to interpret the data in the provided std::io:Read as a WASM binary
 /// module. If an error occurs, a ParseError will be returned containing the
 /// portion of the module that was successfully decoded.
-pub fn parse_wasm_data(src: &mut impl Read) -> Result<Module<Resolved>> {
+pub fn parse_wasm_data(src: &mut impl Read) -> Result<Module<Resolved, UncompiledExpr<Resolved>>> {
     let reader = ReadWithLocation::new(src);
     let mut parser = BinaryParser::new(reader);
     parser.parse()

--- a/wrausmt-format/src/text/mod.rs
+++ b/wrausmt-format/src/text/mod.rs
@@ -2,7 +2,7 @@ use {
     self::parse::Parser,
     super::text::parse::error::Result,
     std::io::Read,
-    wrausmt_runtime::syntax::{Module, Resolved},
+    wrausmt_runtime::syntax::{Module, Resolved, UncompiledExpr},
 };
 
 pub mod lex;
@@ -16,7 +16,9 @@ pub mod parse;
 pub mod resolve;
 pub mod string;
 
-pub fn parse_wast_data(reader: &mut impl Read) -> Result<Module<Resolved>> {
+pub fn parse_wast_data(
+    reader: &mut impl Read,
+) -> Result<Module<Resolved, UncompiledExpr<Resolved>>> {
     let mut parser = Parser::new(reader);
     parser.parse_full_module()
 }

--- a/wrausmt-format/src/text/parse/table.rs
+++ b/wrausmt-format/src/text/parse/table.rs
@@ -3,20 +3,20 @@ use {
     std::io::Read,
     wrausmt_runtime::syntax::{
         types::{RefType, TableType},
-        ElemField, ElemList, Expr, ImportDesc, ImportField, Instruction, ModeEntry, TableField,
-        TablePosition, TableUse, Unresolved,
+        ElemField, ElemList, ImportDesc, ImportField, Instruction, ModeEntry, TableField,
+        TablePosition, TableUse, UncompiledExpr, Unresolved,
     },
 };
 
 impl<R: Read> Parser<R> {
-    fn try_index_as_funcref(&mut self) -> Result<Option<Expr<Unresolved>>> {
+    fn try_index_as_funcref(&mut self) -> Result<Option<UncompiledExpr<Unresolved>>> {
         pctx!(self, "try index as funcref");
-        Ok(self.try_index()?.map(|idx| Expr {
+        Ok(self.try_index()?.map(|idx| UncompiledExpr {
             instr: vec![Instruction::reffunc(idx)],
         }))
     }
 
-    fn read_table_inline_func_elems(&mut self) -> Result<ElemList<Unresolved>> {
+    fn read_table_inline_func_elems(&mut self) -> Result<ElemList<UncompiledExpr<Unresolved>>> {
         pctx!(self, "read table inline func elems");
         // ‘(’ ‘𝚝𝚊𝚋𝚕𝚎’  𝚒𝚍?  𝚛𝚎𝚏𝚝𝚢𝚙𝚎  ‘(’ ‘𝚎𝚕𝚎𝚖’  𝚎𝚕𝚎𝚖𝚕𝚒𝚜𝚝 ‘)’
         // ‘(’ ‘𝚝𝚊𝚋𝚕𝚎’  𝚒𝚍?  𝚛𝚎𝚏𝚝𝚢𝚙𝚎  ‘(’ ‘𝚎𝚕𝚎𝚖’  𝑥𝑛:𝚟𝚎𝚌(𝚎𝚡𝚙𝚛) ‘)’  ‘)’
@@ -96,7 +96,10 @@ impl<R: Read> Parser<R> {
     // elemexpr := ('item' <expr>)
     //           | <instr>
     //           | func <index>*
-    fn try_elemlist(&mut self, allow_bare_funcidx: bool) -> Result<ElemList<Unresolved>> {
+    fn try_elemlist(
+        &mut self,
+        allow_bare_funcidx: bool,
+    ) -> Result<ElemList<UncompiledExpr<Unresolved>>> {
         pctx!(self, "try elemlist");
         let _reftype = self.try_reftype()?;
         let items = self.zero_or_more(Self::try_item_expression)?;

--- a/wrausmt-format/src/text/resolve.rs
+++ b/wrausmt-format/src/text/resolve.rs
@@ -6,10 +6,10 @@ use {
     wrausmt_common::true_or::TrueOr,
     wrausmt_runtime::syntax::{
         DataField, DataIndex, DataInit, ElemField, ElemIndex, ElemList, ExportDesc, ExportField,
-        Expr, FParam, FuncField, FuncIndex, GlobalField, GlobalIndex, Id, ImportDesc, ImportField,
-        Index, Instruction, LabelIndex, LocalIndex, MemoryIndex, ModeEntry, Module, Operands,
-        Resolved, StartField, TableIndex, TablePosition, TableUse, TypeField, TypeIndex, TypeUse,
-        Unresolved,
+        FParam, FuncField, FuncIndex, GlobalField, GlobalIndex, Id, ImportDesc, ImportField, Index,
+        Instruction, LabelIndex, LocalIndex, MemoryIndex, ModeEntry, Module, Operands, Resolved,
+        StartField, TableIndex, TablePosition, TableUse, TypeField, TypeIndex, TypeUse,
+        UncompiledExpr, Unresolved,
     },
 };
 
@@ -195,10 +195,10 @@ index_resolver! {DataIndex, ic, dataindex}
 index_resolver! {LocalIndex, ic, localindex}
 index_resolver! {LabelIndex, ic, labelindex [UnresolvedLabel] }
 
-impl Resolve<Expr<Resolved>> for Expr<Unresolved> {
-    fn resolve(self, ic: &mut ResolutionContext) -> Result<Expr<Resolved>> {
+impl Resolve<UncompiledExpr<Resolved>> for UncompiledExpr<Unresolved> {
+    fn resolve(self, ic: &mut ResolutionContext) -> Result<UncompiledExpr<Resolved>> {
         let instr = resolve_all!(self.instr, ic)?;
-        Ok(Expr { instr })
+        Ok(UncompiledExpr { instr })
     }
 }
 
@@ -263,8 +263,8 @@ impl Resolve<Operands<Resolved>> for Operands<Unresolved> {
     }
 }
 
-impl Resolve<ElemList<Resolved>> for ElemList<Unresolved> {
-    fn resolve(self, ic: &mut ResolutionContext) -> Result<ElemList<Resolved>> {
+impl Resolve<ElemList<UncompiledExpr<Resolved>>> for ElemList<UncompiledExpr<Unresolved>> {
+    fn resolve(self, ic: &mut ResolutionContext) -> Result<ElemList<UncompiledExpr<Resolved>>> {
         let items = resolve_all!(self.items, ic)?;
         Ok(ElemList {
             reftype: self.reftype,
@@ -316,8 +316,8 @@ impl Resolve<ExportDesc<Resolved>> for ExportDesc<Unresolved> {
     }
 }
 
-impl Resolve<GlobalField<Resolved>> for GlobalField<Unresolved> {
-    fn resolve(self, ic: &mut ResolutionContext) -> Result<GlobalField<Resolved>> {
+impl Resolve<GlobalField<UncompiledExpr<Resolved>>> for GlobalField<UncompiledExpr<Unresolved>> {
+    fn resolve(self, ic: &mut ResolutionContext) -> Result<GlobalField<UncompiledExpr<Resolved>>> {
         Ok(GlobalField {
             id:         self.id,
             exports:    self.exports,
@@ -335,8 +335,13 @@ impl Resolve<StartField<Resolved>> for StartField<Unresolved> {
     }
 }
 
-impl Resolve<ElemField<Resolved>> for ElemField<Unresolved> {
-    fn resolve(self, ic: &mut ResolutionContext) -> Result<ElemField<Resolved>> {
+impl Resolve<ElemField<Resolved, UncompiledExpr<Resolved>>>
+    for ElemField<Unresolved, UncompiledExpr<Unresolved>>
+{
+    fn resolve(
+        self,
+        ic: &mut ResolutionContext,
+    ) -> Result<ElemField<Resolved, UncompiledExpr<Resolved>>> {
         Ok(ElemField {
             id:       self.id,
             mode:     self.mode.resolve(ic)?,
@@ -345,8 +350,13 @@ impl Resolve<ElemField<Resolved>> for ElemField<Unresolved> {
     }
 }
 
-impl Resolve<ModeEntry<Resolved>> for ModeEntry<Unresolved> {
-    fn resolve(self, ic: &mut ResolutionContext) -> Result<ModeEntry<Resolved>> {
+impl Resolve<ModeEntry<Resolved, UncompiledExpr<Resolved>>>
+    for ModeEntry<Unresolved, UncompiledExpr<Unresolved>>
+{
+    fn resolve(
+        self,
+        ic: &mut ResolutionContext,
+    ) -> Result<ModeEntry<Resolved, UncompiledExpr<Resolved>>> {
         Ok(match self {
             ModeEntry::Passive => ModeEntry::Passive,
             ModeEntry::Active(tp) => ModeEntry::Active(tp.resolve(ic)?),
@@ -355,8 +365,13 @@ impl Resolve<ModeEntry<Resolved>> for ModeEntry<Unresolved> {
     }
 }
 
-impl Resolve<TablePosition<Resolved>> for TablePosition<Unresolved> {
-    fn resolve(self, ic: &mut ResolutionContext) -> Result<TablePosition<Resolved>> {
+impl Resolve<TablePosition<Resolved, UncompiledExpr<Resolved>>>
+    for TablePosition<Unresolved, UncompiledExpr<Unresolved>>
+{
+    fn resolve(
+        self,
+        ic: &mut ResolutionContext,
+    ) -> Result<TablePosition<Resolved, UncompiledExpr<Resolved>>> {
         Ok(TablePosition {
             tableuse: self.tableuse.resolve(ic)?,
             offset:   self.offset.resolve(ic)?,
@@ -372,8 +387,13 @@ impl Resolve<TableUse<Resolved>> for TableUse<Unresolved> {
     }
 }
 
-impl Resolve<DataField<Resolved>> for DataField<Unresolved> {
-    fn resolve(self, ic: &mut ResolutionContext) -> Result<DataField<Resolved>> {
+impl Resolve<DataField<Resolved, UncompiledExpr<Resolved>>>
+    for DataField<Unresolved, UncompiledExpr<Unresolved>>
+{
+    fn resolve(
+        self,
+        ic: &mut ResolutionContext,
+    ) -> Result<DataField<Resolved, UncompiledExpr<Resolved>>> {
         let init = resolve_option!(self.init, ic);
         Ok(DataField {
             id: self.id,
@@ -383,8 +403,13 @@ impl Resolve<DataField<Resolved>> for DataField<Unresolved> {
     }
 }
 
-impl Resolve<DataInit<Resolved>> for DataInit<Unresolved> {
-    fn resolve(self, ic: &mut ResolutionContext) -> Result<DataInit<Resolved>> {
+impl Resolve<DataInit<Resolved, UncompiledExpr<Resolved>>>
+    for DataInit<Unresolved, UncompiledExpr<Unresolved>>
+{
+    fn resolve(
+        self,
+        ic: &mut ResolutionContext,
+    ) -> Result<DataInit<Resolved, UncompiledExpr<Resolved>>> {
         Ok(DataInit {
             memidx: self.memidx.resolve(ic)?,
             offset: self.offset.resolve(ic)?,
@@ -393,11 +418,17 @@ impl Resolve<DataInit<Resolved>> for DataInit<Unresolved> {
 }
 
 pub trait ResolveModule {
-    fn resolve(self, idents: &ModuleIdentifiers) -> Result<Module<Resolved>>;
+    fn resolve(
+        self,
+        idents: &ModuleIdentifiers,
+    ) -> Result<Module<Resolved, UncompiledExpr<Resolved>>>;
 }
 
-impl ResolveModule for Module<Unresolved> {
-    fn resolve(mut self, mi: &ModuleIdentifiers) -> Result<Module<Resolved>> {
+impl ResolveModule for Module<Unresolved, UncompiledExpr<Unresolved>> {
+    fn resolve(
+        mut self,
+        mi: &ModuleIdentifiers,
+    ) -> Result<Module<Resolved, UncompiledExpr<Resolved>>> {
         let mut rc = ResolutionContext::new(mi, &mut self.types);
         let customs = self.customs;
         let funcs = resolve_all!(self.funcs, &mut rc)?;
@@ -517,8 +548,13 @@ fn validate_inline_typeuse(typeuse: &TypeUse<Unresolved>, ic: &ResolutionContext
     }
 }
 
-impl Resolve<FuncField<Resolved>> for FuncField<Unresolved> {
-    fn resolve(self, ic: &mut ResolutionContext) -> Result<FuncField<Resolved>> {
+impl Resolve<FuncField<Resolved, UncompiledExpr<Resolved>>>
+    for FuncField<Unresolved, UncompiledExpr<Unresolved>>
+{
+    fn resolve(
+        self,
+        ic: &mut ResolutionContext,
+    ) -> Result<FuncField<Resolved, UncompiledExpr<Resolved>>> {
         validate_inline_typeuse(&self.typeuse, ic)?;
 
         let typeuse = self.typeuse.resolve(ic)?;

--- a/wrausmt-runtime/src/runtime/compile.rs
+++ b/wrausmt-runtime/src/runtime/compile.rs
@@ -4,7 +4,7 @@ use crate::{
     syntax::{
         self,
         types::{FunctionType, RefType, ValueType},
-        Expr, FuncField, Instruction, Opcode, Resolved, TypeUse,
+        FuncField, Instruction, Opcode, Resolved, TypeUse, UncompiledExpr,
     },
     validation::{Result, Validation, ValidationContext, ValidationMode},
 };
@@ -61,7 +61,7 @@ pub trait Emitter {
     fn emit_block(
         &mut self,
         typeuse: &syntax::TypeUse<Resolved>,
-        expr: &syntax::Expr<Resolved>,
+        expr: &syntax::UncompiledExpr<Resolved>,
         cnt: &syntax::Continuation,
     ) -> Result<()> {
         let startcnt = self.len() as u32 - 1;
@@ -102,8 +102,8 @@ pub trait Emitter {
     fn emit_if(
         &mut self,
         typeuse: &TypeUse<Resolved>,
-        th: &Expr<Resolved>,
-        el: &Expr<Resolved>,
+        th: &UncompiledExpr<Resolved>,
+        el: &UncompiledExpr<Resolved>,
     ) -> Result<()> {
         self.emit32(typeuse.index().value());
 
@@ -131,7 +131,7 @@ pub trait Emitter {
         Ok(())
     }
 
-    fn emit_expr(&mut self, expr: &syntax::Expr<Resolved>) -> Result<()> {
+    fn emit_expr(&mut self, expr: &syntax::UncompiledExpr<Resolved>) -> Result<()> {
         for instr in &expr.instr {
             self.validate_instr(instr)?;
 
@@ -269,7 +269,7 @@ impl<'a> Emitter for Compiler<'a> {
 /// indices.
 pub fn compile_function_body(
     validation_mode: ValidationMode,
-    func: &FuncField<Resolved>,
+    func: &FuncField<Resolved, UncompiledExpr<Resolved>>,
     functype: &FunctionType,
     modinst: &ModuleInstance,
 ) -> Result<Box<[u8]>> {
@@ -290,7 +290,7 @@ pub fn compile_function_body(
 /// indices. A final `END` opcode will not be emitted.
 pub fn compile_simple_expression(
     validation_mode: ValidationMode,
-    expr: &Expr<Resolved>,
+    expr: &UncompiledExpr<Resolved>,
     modinst: &ModuleInstance,
 ) -> Result<Box<[u8]>> {
     let mut out = Compiler::new(validation_mode, modinst, &[], &[]);

--- a/wrausmt-runtime/src/runtime/instantiate.rs
+++ b/wrausmt-runtime/src/runtime/instantiate.rs
@@ -18,8 +18,8 @@ use {
         syntax::{
             self,
             types::{FunctionType, ValueType},
-            DataInit, ElemList, Expr, FuncField, ImportDesc, Instruction, ModeEntry, Resolved,
-            TablePosition,
+            DataInit, ElemList, FuncField, ImportDesc, Instruction, ModeEntry, Resolved,
+            TablePosition, UncompiledExpr,
         },
         validation::ValidationMode,
     },
@@ -32,7 +32,7 @@ impl Runtime {
     /// [syntax::Module].
     pub fn load(
         &mut self,
-        module: syntax::Module<Resolved>,
+        module: syntax::Module<Resolved, UncompiledExpr<Resolved>>,
         validation_mode: ValidationMode,
     ) -> Result<Rc<ModuleInstance>> {
         self.instantiate(module, validation_mode)
@@ -90,7 +90,7 @@ impl Runtime {
 
     /// Instantiate a function from the provided FuncField and module instance.
     fn instantiate_function(
-        f: FuncField<Resolved>,
+        f: FuncField<Resolved, UncompiledExpr<Resolved>>,
         types: &[FunctionType],
         modinst: Rc<ModuleInstance>,
         validation_mode: ValidationMode,
@@ -112,15 +112,15 @@ impl Runtime {
 
     fn init_table(
         &mut self,
-        tp: &TablePosition<Resolved>,
-        elemlist: &ElemList<Resolved>,
+        tp: &TablePosition<Resolved, UncompiledExpr<Resolved>>,
+        elemlist: &ElemList<UncompiledExpr<Resolved>>,
         ei: u32,
         validation_mode: ValidationMode,
         modinst: &ModuleInstance,
     ) -> Result<()> {
         let n = elemlist.items.len() as u32;
         let ti = tp.tableuse.tableidx.value();
-        let initexpr = Expr {
+        let initexpr = UncompiledExpr {
             instr: vec![
                 Instruction::i32const(0),
                 Instruction::i32const(n),
@@ -137,13 +137,13 @@ impl Runtime {
 
     fn init_mem(
         &mut self,
-        datainit: DataInit<Resolved>,
+        datainit: DataInit<Resolved, UncompiledExpr<Resolved>>,
         n: u32,
         di: u32,
         validation_mode: ValidationMode,
         modinst: &ModuleInstance,
     ) -> Result<()> {
-        let initexpr = Expr {
+        let initexpr = UncompiledExpr {
             instr: vec![
                 Instruction::i32const(0),
                 Instruction::i32const(n),
@@ -160,7 +160,7 @@ impl Runtime {
 
     fn instantiate(
         &mut self,
-        module: syntax::Module<Resolved>,
+        module: syntax::Module<Resolved, UncompiledExpr<Resolved>>,
         validation_mode: ValidationMode,
     ) -> Result<Rc<ModuleInstance>> {
         let mut modinst_builder = ModuleInstanceBuilder {


### PR DESCRIPTION
This is part of a refactor to move compilation & validation into the
format package, since validation can occur immediately after parsing.
