### PR TITLE
Compile/Validate as part of format crate

### DIFF
--- a/tests-integration/src/spec/error.rs
+++ b/tests-integration/src/spec/error.rs
@@ -1,6 +1,6 @@
 use {
     super::format::ActionResult,
-    wrausmt_format::{loader::LoaderError, text::location::Location},
+    wrausmt_format::{loader::LoaderError, text::location::Location, ValidationError},
     wrausmt_runtime::{
         runtime::{error::RuntimeError, values::Value},
         syntax::Id,
@@ -122,5 +122,11 @@ impl From<LoaderError> for CmdError {
 impl From<TestFailureError> for CmdError {
     fn from(e: TestFailureError) -> Self {
         CmdError::TestFailure(e)
+    }
+}
+
+impl From<ValidationError> for CmdError {
+    fn from(e: ValidationError) -> Self {
+        CmdError::LoaderError(LoaderError::ValidationError(e))
     }
 }

--- a/tests-integration/src/spec/error_mappings.rs
+++ b/tests-integration/src/spec/error_mappings.rs
@@ -13,11 +13,9 @@ use {
             parse::error::{ParseError, ParseErrorKind},
             resolve::ResolveError,
         },
+        ValidationError,
     },
-    wrausmt_runtime::{
-        runtime::error::{RuntimeError, RuntimeErrorKind, TrapKind},
-        validation::ValidationError,
-    },
+    wrausmt_runtime::runtime::error::{RuntimeErrorKind, TrapKind},
 };
 
 pub fn verify_failure<T>(result: CmdResult<T>, failure: &str) -> TestResult<()> {
@@ -32,10 +30,11 @@ pub fn verify_failure<T>(result: CmdResult<T>, failure: &str) -> TestResult<()> 
             kind,
             ..
         }))) if matches_bin_parse_error(failure, &kind) => Ok(()),
-        Err(CmdError::InvocationError(RuntimeError {
-            kind: RuntimeErrorKind::ValidationError(ve),
-            ..
-        })) if matches_validation_error(failure, &ve) => Ok(()),
+        Err(CmdError::LoaderError(LoaderError::ValidationError(ve)))
+            if matches_validation_error(failure, &ve) =>
+        {
+            Ok(())
+        }
         Err(e) => Err(TestFailureError::failure_mismatch(failure, e)),
         _ => Err(TestFailureError::failure_missing(failure)),
     }

--- a/tests-integration/src/spec/spectest_module.rs
+++ b/tests-integration/src/spec/spectest_module.rs
@@ -1,10 +1,13 @@
 use {
-    wrausmt_format::text::{module_builder::ModuleBuilder, resolve::Result},
+    wrausmt_format::{
+        compiler::compile_module, loader::Result, text::module_builder::ModuleBuilder,
+        ValidationMode,
+    },
     wrausmt_runtime::syntax::{
         self,
         types::{GlobalType, Limits, MemType, NumType, TableType, ValueType},
-        FParam, FuncField, FunctionType, GlobalField, Instruction, MemoryField, Resolved,
-        TableField, TypeUse, UncompiledExpr, Unresolved,
+        CompiledExpr, FParam, FuncField, FunctionType, GlobalField, Instruction, MemoryField,
+        Resolved, TableField, TypeUse, UncompiledExpr, Unresolved,
     },
 };
 
@@ -26,7 +29,7 @@ use {
 ///  (func (export "print_i32_f32") (param i32 f32))
 ///  (func (export "print_f64_f64") (param f64 f64))
 /// )
-pub fn make_spectest_module() -> Result<syntax::Module<Resolved, UncompiledExpr<Resolved>>> {
+pub fn make_spectest_module() -> Result<syntax::Module<Resolved, CompiledExpr>> {
     let mut builder = ModuleBuilder::default();
 
     builder.add_globalfield(GlobalField {
@@ -142,7 +145,8 @@ pub fn make_spectest_module() -> Result<syntax::Module<Resolved, UncompiledExpr<
         },
     ]))?;
 
-    builder.build()
+    let resolved = builder.build()?;
+    Ok(compile_module(ValidationMode::Fail, resolved)?)
 }
 
 fn mkfunc(

--- a/tests-integration/tests/spec/mod.rs
+++ b/tests-integration/tests/spec/mod.rs
@@ -4,7 +4,7 @@ use {
         loader::parse_and_run,
         runner::{RunConfig, RunSet},
     },
-    wrausmt_runtime::validation::ValidationMode,
+    wrausmt_format::ValidationMode,
 };
 
 const GLOBAL_FAILURES_TO_IGNORE: &[&str] = &[

--- a/tests-integration/tests/validation/mod.rs
+++ b/tests-integration/tests/validation/mod.rs
@@ -4,7 +4,7 @@ use {
         loader::parse_and_run,
         runner::{RunConfig, RunSet},
     },
-    wrausmt_runtime::validation::ValidationMode,
+    wrausmt_format::ValidationMode,
 };
 
 const RUN_CONFIG: RunConfig = RunConfig {

--- a/wrausmt-bin/src/main.rs
+++ b/wrausmt-bin/src/main.rs
@@ -1,6 +1,6 @@
 use {
-    wrausmt_format::file_loader::FileLoader,
-    wrausmt_runtime::{runtime::Runtime, validation::ValidationMode},
+    wrausmt_format::{file_loader::FileLoader, ValidationMode},
+    wrausmt_runtime::runtime::Runtime,
 };
 
 #[derive(Debug)]

--- a/wrausmt-format/src/compiler/mod.rs
+++ b/wrausmt-format/src/compiler/mod.rs
@@ -1,0 +1,214 @@
+mod emitter;
+mod validation;
+pub use validation::{ValidationError, ValidationMode};
+use {
+    self::emitter::ValidatingEmitter,
+    validation::Result,
+    wrausmt_runtime::syntax::{
+        CompiledExpr, DataField, DataInit, ElemField, ElemList, FuncField, GlobalField,
+        Instruction, ModeEntry, Module, Resolved, TablePosition, UncompiledExpr,
+    },
+};
+
+// Compiles all functions in the module.
+// It will consume the provided module, so you should clone the module if you
+// need to do anything else with it later.
+pub fn compile_module(
+    validation_mode: ValidationMode,
+    module: Module<Resolved, UncompiledExpr<Resolved>>,
+) -> Result<Module<Resolved, CompiledExpr>> {
+    let mut module = module;
+    let funcs: Result<Vec<_>> = std::mem::take(&mut module.funcs)
+        .into_iter()
+        .map(|f| compile_func(validation_mode, &module, f))
+        .collect();
+    let funcs = funcs?;
+
+    let globals: Result<Vec<_>> = std::mem::take(&mut module.globals)
+        .into_iter()
+        .map(|g| compile_global(validation_mode, &module, g))
+        .collect();
+    let globals = globals?;
+
+    let elems: Result<Vec<_>> = std::mem::take(&mut module.elems)
+        .into_iter()
+        .enumerate()
+        .map(|(i, e)| compile_elem(validation_mode, &module, e, i))
+        .collect();
+    let elems = elems?;
+
+    let data: Result<Vec<_>> = std::mem::take(&mut module.data)
+        .into_iter()
+        .enumerate()
+        .map(|(i, d)| compile_data(validation_mode, &module, d, i))
+        .collect();
+    let data = data?;
+
+    Ok(Module {
+        id: module.id,
+        customs: module.customs,
+        types: module.types,
+        funcs,
+        tables: module.tables,
+        memories: module.memories,
+        imports: module.imports,
+        exports: module.exports,
+        globals,
+        start: module.start,
+        elems,
+        data,
+    })
+}
+
+fn compile_func(
+    validation_mode: ValidationMode,
+    module: &Module<Resolved, UncompiledExpr<Resolved>>,
+    func: FuncField<Resolved, UncompiledExpr<Resolved>>,
+) -> Result<FuncField<Resolved, CompiledExpr>> {
+    let body = ValidatingEmitter::function_body(validation_mode, module, &func)?;
+    Ok(FuncField {
+        id: func.id,
+        exports: func.exports,
+        typeuse: func.typeuse,
+        locals: func.locals,
+        body,
+    })
+}
+
+fn compile_global(
+    validation_mode: ValidationMode,
+    module: &Module<Resolved, UncompiledExpr<Resolved>>,
+    global: GlobalField<UncompiledExpr<Resolved>>,
+) -> Result<GlobalField<CompiledExpr>> {
+    Ok(GlobalField {
+        id:         global.id,
+        exports:    global.exports,
+        globaltype: global.globaltype,
+        init:       ValidatingEmitter::simple_expression(validation_mode, module, &global.init)?,
+    })
+}
+
+fn compile_elem(
+    validation_mode: ValidationMode,
+    module: &Module<Resolved, UncompiledExpr<Resolved>>,
+    elem: ElemField<Resolved, UncompiledExpr<Resolved>>,
+    ei: usize,
+) -> Result<ElemField<Resolved, CompiledExpr>> {
+    Ok(ElemField {
+        id:       elem.id,
+        mode:     compile_elem_mode(
+            validation_mode,
+            module,
+            elem.mode,
+            elem.elemlist.items.len(),
+            ei,
+        )?,
+        elemlist: compile_elem_list(validation_mode, module, elem.elemlist)?,
+    })
+}
+
+fn compile_data(
+    validation_mode: ValidationMode,
+    module: &Module<Resolved, UncompiledExpr<Resolved>>,
+    data: DataField<Resolved, UncompiledExpr<Resolved>>,
+    di: usize,
+) -> Result<DataField<Resolved, CompiledExpr>> {
+    let dlen = data.data.len();
+    Ok(DataField {
+        id:   data.id,
+        data: data.data,
+        init: match data.init {
+            Some(data_init) => Some(compile_data_init(
+                validation_mode,
+                module,
+                data_init,
+                dlen,
+                di,
+            )?),
+            None => None,
+        },
+    })
+}
+
+fn compile_table_position(
+    validation_mode: ValidationMode,
+    module: &Module<Resolved, UncompiledExpr<Resolved>>,
+    table_position: TablePosition<Resolved, UncompiledExpr<Resolved>>,
+    cnt: usize,
+    ei: usize,
+) -> Result<TablePosition<Resolved, CompiledExpr>> {
+    let ti = table_position.tableuse.tableidx.value();
+    let init_expr = UncompiledExpr {
+        instr: vec![
+            Instruction::i32const(0),
+            Instruction::i32const(cnt as u32),
+            Instruction::tableinit(ti, ei as u32),
+            Instruction::elemdrop(ei as u32),
+        ],
+    };
+    Ok(TablePosition {
+        tableuse: table_position.tableuse,
+        offset:   ValidatingEmitter::simple_expressions(validation_mode, module, &[
+            &table_position.offset,
+            &init_expr,
+        ])?,
+    })
+}
+fn compile_elem_mode(
+    validation_mode: ValidationMode,
+    module: &Module<Resolved, UncompiledExpr<Resolved>>,
+    elem_mode: ModeEntry<Resolved, UncompiledExpr<Resolved>>,
+    cnt: usize,
+    ei: usize,
+) -> Result<ModeEntry<Resolved, CompiledExpr>> {
+    Ok(match elem_mode {
+        ModeEntry::Active(tp) => ModeEntry::Active(compile_table_position(
+            validation_mode,
+            module,
+            tp,
+            cnt,
+            ei,
+        )?),
+        ModeEntry::Passive => ModeEntry::Passive,
+        ModeEntry::Declarative => ModeEntry::Declarative,
+    })
+}
+
+fn compile_elem_list(
+    validation_mode: ValidationMode,
+    module: &Module<Resolved, UncompiledExpr<Resolved>>,
+    elem_list: ElemList<UncompiledExpr<Resolved>>,
+) -> Result<ElemList<CompiledExpr>> {
+    Ok(ElemList {
+        reftype: elem_list.reftype,
+        items:   elem_list
+            .items
+            .iter()
+            .map(|e| ValidatingEmitter::simple_expression(validation_mode, module, e))
+            .collect::<Result<Vec<_>>>()?,
+    })
+}
+
+fn compile_data_init(
+    validation_mode: ValidationMode,
+    module: &Module<Resolved, UncompiledExpr<Resolved>>,
+    data_init: DataInit<Resolved, UncompiledExpr<Resolved>>,
+    cnt: usize,
+    di: usize,
+) -> Result<DataInit<Resolved, CompiledExpr>> {
+    let init_expr = UncompiledExpr {
+        instr: vec![
+            Instruction::i32const(0),
+            Instruction::i32const(cnt as u32),
+            Instruction::meminit(di as u32),
+            Instruction::datadrop(di as u32),
+        ],
+    };
+    Ok(DataInit {
+        memidx: data_init.memidx,
+        offset: ValidatingEmitter::simple_expressions(validation_mode, module, &[
+            &data_init.offset,
+            &init_expr,
+        ])?,
+    })
+}

--- a/wrausmt-format/src/compiler/validation/ops.rs
+++ b/wrausmt-format/src/compiler/validation/ops.rs
@@ -1,6 +1,6 @@
 use {
     super::{Result, Validation, ValidationError, ValidationMode},
-    crate::{
+    wrausmt_runtime::{
         instructions::opcodes,
         syntax::{
             types::{NumType, ValueType},
@@ -30,14 +30,14 @@ impl<'a> Validation<'a> {
     }
 
     fn validate_results(&mut self) -> Result<()> {
-        for r in self.validation_context.resulttypes {
+        for r in self.resulttypes {
             self.pop_expect(*r)?;
         }
         Ok(())
     }
 
     fn error_for_mode(&mut self, op: impl Fn(&mut Self) -> Result<()>) -> Result<()> {
-        match (self.validation_context.mode, op(self)) {
+        match (self.mode, op(self)) {
             (_, Ok(())) => Ok(()),
             (ValidationMode::Warn, Err(e)) => {
                 println!("WARNING: Validation Failed: {e:?}");
@@ -71,7 +71,6 @@ impl<'a> Validation<'a> {
     fn local_type(&mut self, operands: &Operands<Resolved>) -> Result<ValueType> {
         match operands {
             Operands::LocalIndex(li) => Ok(*self
-                .validation_context
                 .localtypes
                 .get(li.value() as usize)
                 .ok_or(ValidationError::UnknownLocal(li.clone()))?),

--- a/wrausmt-format/src/file_loader.rs
+++ b/wrausmt-format/src/file_loader.rs
@@ -1,14 +1,14 @@
 use {
-    crate::loader::{Loader, Result},
+    crate::{
+        compiler::ValidationMode,
+        loader::{Loader, Result},
+    },
     std::{
         fs::File,
         io::{Read, Seek, SeekFrom},
         rc::Rc,
     },
-    wrausmt_runtime::{
-        runtime::{instance::ModuleInstance, Runtime},
-        validation::ValidationMode,
-    },
+    wrausmt_runtime::runtime::{instance::ModuleInstance, Runtime},
 };
 
 pub trait FileLoader: Loader {

--- a/wrausmt-format/src/lib.rs
+++ b/wrausmt-format/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod binary;
+pub mod compiler;
 pub mod file_loader;
 pub mod loader;
 pub mod text;
+
+pub use compiler::{ValidationError, ValidationMode};

--- a/wrausmt-runtime/src/lib.rs
+++ b/wrausmt-runtime/src/lib.rs
@@ -3,4 +3,3 @@ pub mod instructions;
 mod log_tag;
 pub mod runtime;
 pub mod syntax;
-pub mod validation;

--- a/wrausmt-runtime/src/runtime/error.rs
+++ b/wrausmt-runtime/src/runtime/error.rs
@@ -1,9 +1,6 @@
 use {
     super::instance::ExternalVal,
-    crate::{
-        syntax::{ImportDesc, Resolved},
-        validation::ValidationError,
-    },
+    crate::syntax::{ImportDesc, Resolved},
     std::fmt,
 };
 
@@ -46,7 +43,6 @@ pub enum RuntimeErrorKind {
     ImportNotFound(String, String),
     ImportMismatch(ImportDesc<Resolved>, ExternalVal),
     ImplementationBug(String),
-    ValidationError(ValidationError),
     ArgumentCountError { expected: usize, got: usize },
     CallStackExhaustion,
     Trap(TrapKind),
@@ -75,14 +71,6 @@ impl From<RuntimeErrorKind> for RuntimeError {
     fn from(value: RuntimeErrorKind) -> Self {
         RuntimeError {
             kind:    value,
-            context: vec![],
-        }
-    }
-}
-impl From<ValidationError> for RuntimeError {
-    fn from(value: ValidationError) -> Self {
-        RuntimeError {
-            kind:    RuntimeErrorKind::ValidationError(value),
             context: vec![],
         }
     }

--- a/wrausmt-runtime/src/runtime/instance/mem_instance.rs
+++ b/wrausmt-runtime/src/runtime/instance/mem_instance.rs
@@ -1,9 +1,8 @@
 use {
     crate::{
         log_tag::Tag,
-        runtime::error::{Result, RuntimeErrorKind, TrapKind},
+        runtime::error::{Result, TrapKind},
         syntax::{types::MemType, MemoryField},
-        validation::ValidationError,
     },
     std::ops::Range,
     wrausmt_common::{
@@ -53,16 +52,12 @@ impl MemInstance {
 
     pub fn new_ast(memfield: MemoryField) -> Result<MemInstance> {
         let memtype = memfield.memtype;
-        if memtype.limits.lower > 65536 {
-            Err(RuntimeErrorKind::ValidationError(ValidationError::MemoryTooLarge).into())
-        } else {
-            let data = vec![0u8; memtype.limits.lower as usize * PAGE_SIZE];
-            Ok(MemInstance {
-                logger: PrintLogger,
-                memtype,
-                data,
-            })
-        }
+        let data = vec![0u8; memtype.limits.lower as usize * PAGE_SIZE];
+        Ok(MemInstance {
+            logger: PrintLogger,
+            memtype,
+            data,
+        })
     }
 
     pub fn size(&self) -> usize {

--- a/wrausmt-runtime/src/runtime/instance/table_instance.rs
+++ b/wrausmt-runtime/src/runtime/instance/table_instance.rs
@@ -1,10 +1,9 @@
 use crate::{
     runtime::{
-        error::{Result, RuntimeErrorKind, TrapKind},
+        error::{Result, TrapKind},
         values::Ref,
     },
     syntax::types::TableType,
-    validation::ValidationError,
 };
 
 /// A table instance is the runtime representation of a table. [Spec][Spec]
@@ -28,11 +27,6 @@ pub struct TableInstance {
 
 impl TableInstance {
     pub fn new(tabletype: TableType) -> Result<TableInstance> {
-        if tabletype.limits.lower > 0xFFFF {
-            Err(RuntimeErrorKind::ValidationError(
-                ValidationError::TableTooLarge,
-            ))?;
-        }
         let elem: Vec<Ref> = std::iter::repeat(tabletype.reftype.default())
             .take(tabletype.limits.lower as usize)
             .collect();

--- a/wrausmt-runtime/src/runtime/mod.rs
+++ b/wrausmt-runtime/src/runtime/mod.rs
@@ -4,7 +4,6 @@ use {
     wrausmt_common::logger::{Logger, PrintLogger},
 };
 
-mod compile;
 pub mod error;
 pub mod exec;
 pub mod instance;

--- a/wrausmt-runtime/src/syntax/indices.rs
+++ b/wrausmt-runtime/src/syntax/indices.rs
@@ -11,11 +11,6 @@ marker!(
     Resolved: ResolvedState
 );
 marker!(
-    /// A module parameterized by the [IndicesResolved] type will have undergone
-    /// index resolution, but not type use resolution.
-    IndicesResolved: ResolvedState
-);
-marker!(
     /// A module parameterized by the [Unresolved] type will have undergone index
     /// resolution, and must be compiled before it can be used by the runtime.
     Unresolved: ResolvedState


### PR DESCRIPTION
This is a big change, but just a few themes:
* Compilation and Validation logic moves to format crate
* Compilation emitter is cleaned up
* Compliation of module follow a tree pattern similar to resolve.
* Copmilation/Validation happens after parsing, but before instantiation.
* Consolidate ValidationContext and Validation into one.
* Remove an unused marker ResolvedState