### PR TITLE
Make sure end/else instructions get validated

### DIFF
--- a/wrausmt-format/src/compiler/validation/ops.rs
+++ b/wrausmt-format/src/compiler/validation/ops.rs
@@ -82,6 +82,10 @@ impl<'a> Validation<'a> {
         match instr.opcode {
             opcodes::UNREACHABLE => self.unreachable(),
 
+            opcodes::END => {
+                // TODO
+                Ok(())
+            }
             // 0x20
             opcodes::LOCAL_GET => {
                 let ty = self.local_type(&instr.operands)?;


### PR DESCRIPTION
The implementation of the validation isn't done in this CL, but the code is
reorganized so they do run through the validation code instead of just
emitting an opcode.
