### PR TITLE
Tweaks to br-table so syntax follows spec

### DIFF
--- a/codegen/master_ops_list.csv
+++ b/codegen/master_ops_list.csv
@@ -45,13 +45,10 @@
 
 0x0E      ,br_table                      ,(BrTable)
 | let icnt = _ec.op_u32()?;
-| let mut indices: Vec<u32> = Vec::with_capacity(icnt as usize);
-| for _ in 0..icnt {
-|     indices.push(_ec.op_u32()?)
-| }
-| 
-| let sel = std::cmp::min(icnt - 1, _ec.pop::<u32>()?);
-| _ec.br(indices[sel as usize])
+| let sel = std::cmp::min(_ec.pop::<u32>()?, icnt);
+| _ec.skip((sel * 4) as usize);
+| let targ = _ec.op_u32()?;
+| _ec.br(targ)
 
 0x0F      ,return                        ,()
 | _ec.ret()

--- a/wrausmt-format/src/binary/code.rs
+++ b/wrausmt-format/src/binary/code.rs
@@ -201,10 +201,9 @@ impl<R: ParserReader> BinaryParser<R> {
             Operands::MemoryIndex => syntax::Operands::MemoryIndex(self.read_index_use()?),
             Operands::Br => syntax::Operands::LabelIndex(self.read_index_use()?),
             Operands::BrTable => {
-                let mut idxs = self.read_vec(|_, s| s.read_index_use())?;
+                let idxs = self.read_vec(|_, s| s.read_index_use())?;
                 let last = self.read_index_use()?;
-                idxs.push(last);
-                syntax::Operands::BrTable(idxs)
+                syntax::Operands::BrTable(idxs, last)
             }
             Operands::I32 => syntax::Operands::I32(self.read_i32_leb_128().result(self)? as u32),
             Operands::I64 => syntax::Operands::I64(self.read_i64_leb_128().result(self)? as u64),

--- a/wrausmt-format/src/compiler/emitter.rs
+++ b/wrausmt-format/src/compiler/emitter.rs
@@ -60,11 +60,16 @@ pub trait Emitter {
         Ok(())
     }
 
-    fn emit_br_table(&mut self, indices: &[syntax::Index<Resolved, syntax::LabelIndex>]) {
+    fn emit_br_table(
+        &mut self,
+        indices: &[syntax::Index<Resolved, syntax::LabelIndex>],
+        last: &syntax::Index<Resolved, syntax::LabelIndex>,
+    ) {
         self.emit32(indices.len() as u32);
         for i in indices {
             self.emit32(i.value());
         }
+        self.emit32(last.value())
     }
 
     fn emit_if(
@@ -113,7 +118,7 @@ pub trait Emitter {
         match &instr.operands {
             syntax::Operands::None => (),
             syntax::Operands::Block(_, typeuse, e, cnt) => self.emit_block(typeuse, e, cnt)?,
-            syntax::Operands::BrTable(indices) => self.emit_br_table(indices),
+            syntax::Operands::BrTable(indices, last) => self.emit_br_table(indices, last),
             syntax::Operands::CallIndirect(idx, typeuse) => {
                 self.emit32(idx.value());
                 self.emit32(typeuse.index().value());

--- a/wrausmt-format/src/text/parse/instruction.rs
+++ b/wrausmt-format/src/text/parse/instruction.rs
@@ -52,8 +52,13 @@ impl<R: Read> Parser<R> {
                     Operands::LocalIndex => syntax::Operands::LocalIndex(self.expect_index()?),
                     Operands::Br => syntax::Operands::LabelIndex(self.expect_index()?),
                     Operands::BrTable => {
-                        let idxs = self.zero_or_more(Self::try_index)?;
-                        syntax::Operands::BrTable(idxs)
+                        let mut idxs = self.zero_or_more(Self::try_index)?;
+                        let last = match idxs.pop() {
+                            Some(idx) => idx,
+                            // Not a valid br_table without at least one index
+                            None => return Ok(None),
+                        };
+                        syntax::Operands::BrTable(idxs, last)
                     }
                     Operands::Select => {
                         let results = self.zero_or_more_groups(Self::try_parse_fresult)?;

--- a/wrausmt-format/src/text/resolve.rs
+++ b/wrausmt-format/src/text/resolve.rs
@@ -223,7 +223,9 @@ impl Resolve<Operands<Resolved>> for Operands<Unresolved> {
                 let el = el.resolve(&mut bic)?;
                 Operands::If(id, tu, th, el)
             }
-            Operands::BrTable(idxs) => Operands::BrTable(resolve_all!(idxs, ic)?),
+            Operands::BrTable(idxs, last) => {
+                Operands::BrTable(resolve_all!(idxs, ic)?, last.resolve(ic)?)
+            }
             Operands::Select(r) => Operands::Select(r),
             Operands::CallIndirect(idx, tu) => {
                 let idx = idx.resolve(ic)?;

--- a/wrausmt-runtime/src/runtime/exec.rs
+++ b/wrausmt-runtime/src/runtime/exec.rs
@@ -37,6 +37,7 @@ value!(i32, i64, u8, u32, u64, f32, f64, usize, Ref);
 
 pub trait ExecutionContextActions {
     fn log(&self, tag: Tag, msg: impl Fn() -> String);
+    fn skip(&mut self, bytes: usize);
     fn next_byte(&mut self) -> u8;
     fn op_u32(&mut self) -> Result<u32>;
     fn op_u64(&mut self) -> Result<u64>;
@@ -144,6 +145,10 @@ pub trait ExecutionContextActions {
 impl<'l> ExecutionContextActions for ExecutionContext<'l> {
     fn log(&self, tag: Tag, msg: impl Fn() -> String) {
         self.runtime.logger.log(tag, msg);
+    }
+
+    fn skip(&mut self, bytes: usize) {
+        self.pc += bytes;
     }
 
     fn next_byte(&mut self) -> u8 {

--- a/wrausmt-runtime/src/syntax/mod.rs
+++ b/wrausmt-runtime/src/syntax/mod.rs
@@ -702,7 +702,7 @@ pub enum Operands<R: ResolvedState> {
     CallIndirect(Index<R, TableIndex>, TypeUse<R>),
     Block(Option<Id>, TypeUse<R>, UncompiledExpr<R>, Continuation),
     If(Option<Id>, TypeUse<R>, UncompiledExpr<R>, UncompiledExpr<R>),
-    BrTable(Vec<Index<R, LabelIndex>>),
+    BrTable(Vec<Index<R, LabelIndex>>, Index<R, LabelIndex>),
     Select(Vec<FResult>),
     FuncIndex(Index<R, FuncIndex>),
     TableIndex(Index<R, TableIndex>),


### PR DESCRIPTION
Differentiate the last/default target argument, so that the operands
type properly reflects the requirements of the instructions.

Also tweak the exec code to avoid needless parsing of branch targets
that aren't needed.
