### PR TITLE
Organize validation stacks code

### DIFF
--- a/wrausmt-format/src/compiler/validation/mod.rs
+++ b/wrausmt-format/src/compiler/validation/mod.rs
@@ -3,17 +3,15 @@
 //! [Spec]: https://webassembly.github.io/spec/core/appendix/algorithm.html
 
 use {
-    wrausmt_common::true_or::TrueOr,
+    self::stacks::Stacks,
     wrausmt_runtime::{
         instructions::opcodes,
-        syntax::{
-            types::ValueType, Index, LabelIndex, LocalIndex, Module, Opcode, Resolved,
-            UncompiledExpr,
-        },
+        syntax::{types::ValueType, Index, LocalIndex, Module, Opcode, Resolved, UncompiledExpr},
     },
 };
 
 mod ops;
+mod stacks;
 
 #[derive(Debug)]
 pub enum ValidationError {
@@ -57,15 +55,6 @@ pub enum ValidationType {
     #[default]
     Unknown,
     Value(ValueType),
-}
-
-#[derive(Debug, PartialEq)]
-pub struct CtrlFrame {
-    opcode:      Opcode,
-    start_types: Vec<ValueType>,
-    end_types:   Vec<ValueType>,
-    height:      usize,
-    unreachable: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -118,9 +107,7 @@ pub struct Validation<'a> {
     // Func
     pub localtypes: Vec<ValueType>,
 
-    #[allow(dead_code)]
-    val_stack:  Vec<ValueType>,
-    ctrl_stack: Vec<CtrlFrame>,
+    stacks: Stacks,
 }
 
 impl<'a> Validation<'a> {
@@ -130,130 +117,16 @@ impl<'a> Validation<'a> {
         localtypes: Vec<ValueType>,
         resulttypes: Vec<ValueType>,
     ) -> Validation {
+        let stacks = Stacks::new();
         let mut val = Validation {
             mode,
             module,
             localtypes,
-            val_stack: Vec::default(),
-            ctrl_stack: Vec::default(),
+            stacks,
         };
 
-        val.push_ctrl(opcodes::BLOCK, Vec::new(), resulttypes);
+        val.stacks
+            .push_ctrl(opcodes::BLOCK, Vec::new(), resulttypes);
         val
-    }
-
-    fn push_val(&mut self, v: ValueType) {
-        self.val_stack.push(v);
-    }
-
-    fn push_vals(&mut self, vs: &[ValueType]) {
-        for v in vs.iter().rev() {
-            self.val_stack.push(*v);
-        }
-    }
-
-    /// Popping an operand value checks that the value stack does not underflow
-    /// the current block and then removes one type. But first, a special case
-    /// is handled where the block contains no known values, but has been marked
-    /// as unreachable. That can occur after an unconditional branch, when the
-    /// stack is typed polymorphically. In that case, an unknown type is
-    /// returned.
-    ///
-    /// [See Spec](https://webassembly.github.io/spec/core/appendix/algorithm.html#data-structures)
-    fn pop_val(&mut self) -> Result<ValidationType> {
-        let ctrl = self
-            .ctrl_stack
-            .last()
-            .ok_or(ValidationError::CtrlStackUnderflow)?;
-        if self.val_stack.len() == ctrl.height {
-            return if ctrl.unreachable {
-                Ok(ValidationType::Unknown)
-            } else {
-                Err(ValidationError::ValStackUnderflow)
-            };
-        }
-        let val = self
-            .val_stack
-            .pop()
-            .ok_or(ValidationError::ValStackUnderflow)?;
-        Ok(ValidationType::Value(val))
-    }
-
-    fn pop_expect(&mut self, expect: ValueType) -> Result<ValidationType> {
-        let actual = self.pop_val()?;
-        let expect = ValidationType::Value(expect);
-        match (actual, expect) {
-            (ValidationType::Unknown, expect) => Ok(expect),
-            (actual, ValidationType::Unknown) => Ok(actual),
-            (actual, expect) => {
-                if actual == expect {
-                    Ok(actual)
-                } else {
-                    Err(ValidationError::TypeMismatch { actual, expect })
-                }
-            }
-        }
-    }
-
-    fn pop_vals(&mut self, vs: &[ValueType]) -> Result<Vec<ValidationType>> {
-        let mut result: Vec<ValidationType> = vec![];
-        for v in vs.iter().rev() {
-            result.push(self.pop_expect(*v)?);
-        }
-        Ok(result)
-    }
-
-    #[allow(dead_code)]
-    fn push_ctrl(
-        &mut self,
-        opcode: Opcode,
-        start_types: Vec<ValueType>,
-        end_types: Vec<ValueType>,
-    ) {
-        self.push_vals(&start_types);
-        let frame = CtrlFrame {
-            opcode,
-            start_types,
-            end_types,
-            height: self.val_stack.len(),
-            unreachable: false,
-        };
-        self.ctrl_stack.push(frame)
-    }
-
-    #[allow(dead_code)]
-    fn pop_ctrl(&mut self) -> Result<CtrlFrame> {
-        let frame = self
-            .ctrl_stack
-            .last()
-            .ok_or(ValidationError::CtrlStackUnderflow)?;
-        let end_types = frame.end_types.clone();
-        let cur_height = frame.height;
-        self.pop_vals(&end_types)?;
-        (self.val_stack.len() == cur_height).true_or(ValidationError::UnusedValues)?;
-        let frame = self.ctrl_stack.pop().unwrap();
-        Ok(frame)
-    }
-
-    fn label_types(&self, label: &Index<Resolved, LabelIndex>) -> Result<Vec<ValueType>> {
-        let frame = self
-            .ctrl_stack
-            .get(self.ctrl_stack.len() - 1 - label.value() as usize)
-            .ok_or(ValidationError::LabelOutOfRange)?;
-        Ok(if frame.opcode == opcodes::LOOP {
-            frame.start_types.clone()
-        } else {
-            frame.end_types.clone()
-        })
-    }
-
-    fn unreachable(&mut self) -> Result<()> {
-        let frame = self
-            .ctrl_stack
-            .last_mut()
-            .ok_or(ValidationError::CtrlStackUnderflow)?;
-        self.val_stack.truncate(frame.height);
-        frame.unreachable = true;
-        Ok(())
     }
 }

--- a/wrausmt-format/src/compiler/validation/stacks/ctrl_stack.rs
+++ b/wrausmt-format/src/compiler/validation/stacks/ctrl_stack.rs
@@ -1,0 +1,72 @@
+use {
+    crate::compiler::validation::{Result, ValidationError},
+    wrausmt_runtime::{
+        instructions::opcodes,
+        syntax::{types::ValueType, Index, LabelIndex, Opcode, Resolved},
+    },
+};
+
+/// One frame in the ctrl_stack, as defined by the spec.
+///
+/// [Spec]: https://webassembly.github.io/spec/core/appendix/algorithm.html#data-structures
+#[derive(Debug, PartialEq)]
+pub struct CtrlFrame {
+    pub opcode:      Opcode,
+    pub start_types: Vec<ValueType>,
+    pub end_types:   Vec<ValueType>,
+    pub height:      usize,
+    pub unreachable: bool,
+}
+
+/// The ctrl stack for validation, a wrapper around the list of [`CtrlFrame`]
+/// items exposing only well-defined mutation methods.
+#[derive(Default, Debug)]
+pub struct CtrlStack {
+    frames: Vec<CtrlFrame>,
+}
+
+impl CtrlStack {
+    pub fn peek(&self) -> Result<&CtrlFrame> {
+        self.frames
+            .last()
+            .ok_or(ValidationError::CtrlStackUnderflow)
+    }
+
+    pub fn push(&mut self, frame: CtrlFrame) {
+        self.frames.push(frame);
+    }
+
+    pub fn pop(&mut self) -> Result<CtrlFrame> {
+        self.frames.pop().ok_or(ValidationError::CtrlStackUnderflow)
+    }
+
+    pub fn label_types(&self, idx: &Index<Resolved, LabelIndex>) -> Result<Vec<ValueType>> {
+        let frame = self
+            .frames
+            .get(self.frames.len() - 1 - idx.value() as usize)
+            .ok_or(ValidationError::LabelOutOfRange)?;
+
+        Ok(if frame.opcode == opcodes::LOOP {
+            // TODO - return ref?
+            frame.start_types.clone()
+        } else {
+            // TODO - return ref?
+            frame.end_types.clone()
+        })
+    }
+
+    pub fn return_types(&self) -> Result<Vec<ValueType>> {
+        let idx = Index::unnamed((self.frames.len() - 1) as u32);
+        self.label_types(&idx)
+    }
+
+    pub fn unreachable(&mut self) -> Result<usize> {
+        let frame = self
+            .frames
+            .last_mut()
+            .ok_or(ValidationError::CtrlStackUnderflow)?;
+
+        frame.unreachable = true;
+        Ok(frame.height)
+    }
+}

--- a/wrausmt-format/src/compiler/validation/stacks/mod.rs
+++ b/wrausmt-format/src/compiler/validation/stacks/mod.rs
@@ -1,0 +1,116 @@
+use {
+    self::{
+        ctrl_stack::{CtrlFrame, CtrlStack},
+        val_stack::ValueStack,
+    },
+    super::ValidationType,
+    crate::{compiler::validation::Result, ValidationError},
+    wrausmt_common::true_or::TrueOr,
+    wrausmt_runtime::syntax::{types::ValueType, Index, LabelIndex, Opcode, Resolved},
+};
+
+pub struct Stacks {
+    ctrl: CtrlStack,
+    val:  ValueStack,
+}
+
+impl Stacks {
+    pub fn new() -> Stacks {
+        let ctrl = CtrlStack::default();
+        let val = ValueStack::new();
+        Stacks { ctrl, val }
+    }
+
+    pub fn push_val(&mut self, val: ValueType) {
+        self.val.push(val)
+    }
+
+    pub fn push_vals(&mut self, vals: &[ValueType]) {
+        self.val.push_many(vals)
+    }
+
+    pub fn pop_val(&mut self, expect: ValueType) -> Result<ValidationType> {
+        let actual = self.val.pop_val(self.ctrl.peek()?)?;
+        let expect = ValidationType::Value(expect);
+        match (actual, expect) {
+            (ValidationType::Unknown, expect) => Ok(expect),
+            (actual, ValidationType::Unknown) => Ok(actual),
+            (actual, expect) => {
+                if actual == expect {
+                    Ok(actual)
+                } else {
+                    Err(ValidationError::TypeMismatch { actual, expect })
+                }
+            }
+        }
+    }
+
+    pub fn pop_vals(&mut self, vs: &[ValueType]) -> Result<Vec<ValidationType>> {
+        let mut result: Vec<ValidationType> = vec![];
+        for v in vs.iter().rev() {
+            result.push(self.pop_val(*v)?);
+        }
+        Ok(result)
+    }
+
+    pub fn push_ctrl(
+        &mut self,
+        opcode: Opcode,
+        start_types: Vec<ValueType>,
+        end_types: Vec<ValueType>,
+    ) {
+        self.val.push_many(&start_types);
+        let frame = CtrlFrame {
+            opcode,
+            start_types,
+            end_types,
+            height: self.val.len(),
+            unreachable: false,
+        };
+        self.ctrl.push(frame)
+    }
+
+    pub fn pop_ctrl(&mut self) -> Result<CtrlFrame> {
+        let frame = self.ctrl.peek()?;
+        // TODO - remove clone?
+        let end_types = frame.end_types.clone();
+        let cur_height = frame.height;
+        self.pop_vals(&end_types)?;
+        (self.val.len() == cur_height).true_or(ValidationError::UnusedValues)?;
+        self.ctrl.pop()
+    }
+
+    pub fn label_arity(&mut self, idx: &Index<Resolved, LabelIndex>) -> Result<usize> {
+        Ok(self.ctrl.label_types(idx)?.len())
+    }
+
+    pub fn push_label_types(&mut self, idx: &Index<Resolved, LabelIndex>) -> Result<()> {
+        let label_types = self.ctrl.label_types(idx)?;
+        self.push_vals(&label_types);
+        Ok(())
+    }
+
+    pub fn pop_label_types(&mut self, idx: &Index<Resolved, LabelIndex>) -> Result<()> {
+        // TODO - remove clone?
+        let label_types = self.ctrl.label_types(idx)?.clone();
+        self.pop_vals(&label_types).map(|_| ())
+    }
+
+    pub fn pop_return_types(&mut self) -> Result<()> {
+        let label_types = self.ctrl.return_types()?;
+        self.pop_vals(&label_types).map(|_| ())
+    }
+
+    pub fn drop_val(&mut self) -> Result<()> {
+        self.val.drop()
+    }
+
+    pub fn unreachable(&mut self) -> Result<()> {
+        let new_height = self.ctrl.unreachable()?;
+        self.val.truncate(new_height);
+        Ok(())
+    }
+}
+
+mod ctrl_stack;
+mod val_stack;

--- a/wrausmt-format/src/compiler/validation/stacks/val_stack.rs
+++ b/wrausmt-format/src/compiler/validation/stacks/val_stack.rs
@@ -1,0 +1,67 @@
+use {
+    super::ctrl_stack::CtrlFrame,
+    crate::compiler::validation::{Result, ValidationError, ValidationType},
+    wrausmt_runtime::syntax::types::ValueType,
+};
+
+/// The value stack for validation, a wrapper around the list of
+/// [`ValueType`] items exposing only well-defined mutation methods.
+#[derive(Debug)]
+pub struct ValueStack {
+    values: Vec<ValueType>,
+}
+
+impl ValueStack {
+    pub fn new() -> ValueStack {
+        ValueStack { values: vec![] }
+    }
+
+    pub fn push(&mut self, v: ValueType) {
+        self.values.push(v);
+    }
+
+    pub fn push_many(&mut self, vs: &[ValueType]) {
+        for v in vs.iter().rev() {
+            self.values.push(*v);
+        }
+    }
+
+    /// Popping an operand value checks that the value stack does not underflow
+    /// the current block and then removes one type. But first, a special case
+    /// is handled where the block contains no known values, but has been marked
+    /// as unreachable. That can occur after an unconditional branch, when the
+    /// stack is typed polymorphically. In that case, an unknown type is
+    /// returned.
+    ///
+    /// [See Spec](https://webassembly.github.io/spec/core/appendix/algorithm.html#data-structures)
+    pub fn pop_val(&mut self, ctrl: &CtrlFrame) -> Result<ValidationType> {
+        if self.len() == ctrl.height {
+            return if ctrl.unreachable {
+                Ok(ValidationType::Unknown)
+            } else {
+                Err(ValidationError::ValStackUnderflow)
+            };
+        }
+        let val = self
+            .values
+            .pop()
+            .ok_or(ValidationError::ValStackUnderflow)?;
+        Ok(ValidationType::Value(val))
+    }
+
+    pub fn drop(&mut self) -> Result<()> {
+        let _ = self
+            .values
+            .pop()
+            .ok_or(ValidationError::ValStackUnderflow)?;
+        Ok(())
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn truncate(&mut self, height: usize) {
+        self.values.truncate(height)
+    }
+}


### PR DESCRIPTION
Defines different types for CtrlStack, ValStack, and the combination of both
stacks, to clarify the expected usage pattern of these structures.