### PR TITLE
Add location to validation errors

### DIFF
--- a/wrausmt-format/src/binary/data.rs
+++ b/wrausmt-format/src/binary/data.rs
@@ -23,6 +23,7 @@ impl<R: ParserReader> BinaryParser<R> {
 
     fn read_data_field(&mut self) -> Result<DataField<Resolved, UncompiledExpr<Resolved>>> {
         pctx!(self, "read data field");
+        let location = self.reader.location();
         let variants = self.read_u32_leb_128().result(self)?;
         let active = (variants & 0x01) == 0;
         let active_memidx = (variants & 0x02) != 0;
@@ -47,6 +48,7 @@ impl<R: ParserReader> BinaryParser<R> {
             id: None,
             data,
             init,
+            location,
         })
     }
 }

--- a/wrausmt-format/src/binary/globals.rs
+++ b/wrausmt-format/src/binary/globals.rs
@@ -18,11 +18,13 @@ impl<R: ParserReader> BinaryParser<R> {
 
     fn read_global_field(&mut self) -> Result<GlobalField<UncompiledExpr<Resolved>>> {
         pctx!(self, "read global field");
+        let location = self.reader.location();
         Ok(GlobalField {
-            id:         None,
-            exports:    vec![],
+            id: None,
+            exports: vec![],
             globaltype: self.read_global_type()?,
-            init:       self.read_expr(false)?,
+            init: self.read_expr(false)?,
+            location,
         })
     }
 }

--- a/wrausmt-format/src/binary/mod.rs
+++ b/wrausmt-format/src/binary/mod.rs
@@ -201,6 +201,7 @@ impl<T: ParserReader> Locate for BinaryParser<T> {
         self.reader.location()
     }
 }
+
 impl<T: ParserReader> ParserReader for BinaryParser<T> {}
 
 /// Attempt to interpret the data in the provided std::io:Read as a WASM binary

--- a/wrausmt-format/src/compiler/validation/mod.rs
+++ b/wrausmt-format/src/compiler/validation/mod.rs
@@ -8,6 +8,7 @@ use {
         instructions::opcodes,
         syntax::{
             self,
+            location::Location,
             types::{GlobalType, MemType, RefType, TableType, ValueType},
             ImportDesc, Index, Instruction, LocalIndex, Module, Resolved, UncompiledExpr,
         },
@@ -55,12 +56,13 @@ pub enum ValidationErrorKind {
 
 #[derive(Debug)]
 pub struct ValidationError {
-    kind: ValidationErrorKind,
+    kind:     ValidationErrorKind,
+    location: Location,
 }
 
 impl ValidationError {
-    pub fn new(kind: ValidationErrorKind) -> ValidationError {
-        ValidationError { kind }
+    pub fn new(kind: ValidationErrorKind, location: Location) -> ValidationError {
+        ValidationError { kind, location }
     }
 
     pub fn kind(&self) -> &ValidationErrorKind {
@@ -70,7 +72,7 @@ impl ValidationError {
 
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{:?}", self.kind)
+        writeln!(f, "{:?} {:?}", self.location, self.kind)
     }
 }
 
@@ -88,8 +90,9 @@ pub enum ValidationMode {
     // Use panic to abort the entire process if validation fails.
     Panic,
 }
-pub type KindResult<T> = std::result::Result<T, ValidationErrorKind>;
+
 pub type Result<T> = std::result::Result<T, ValidationError>;
+type KindResult<T> = std::result::Result<T, ValidationErrorKind>;
 
 /// Type representations during validation.
 ///

--- a/wrausmt-format/src/compiler/validation/stacks/mod.rs
+++ b/wrausmt-format/src/compiler/validation/stacks/mod.rs
@@ -95,6 +95,8 @@ impl Stacks {
         // TODO - remove clone?
         let end_types = frame.end_types.clone();
         let cur_height = frame.height;
+        println!("STACK {:?}", self.val);
+        println!("POP CTRL VALS {:?}", end_types);
         self.pop_vals(&end_types)?;
         (self.val.len() == cur_height).true_or(ValidationErrorKind::UnusedValues)?;
         self.ctrl.pop()

--- a/wrausmt-format/src/compiler/validation/stacks/val_stack.rs
+++ b/wrausmt-format/src/compiler/validation/stacks/val_stack.rs
@@ -21,7 +21,7 @@ impl ValueStack {
     }
 
     pub fn push_many(&mut self, vs: &[ValueType]) {
-        for v in vs.iter().rev() {
+        for v in vs.iter() {
             self.values.push(*v);
         }
     }

--- a/wrausmt-format/src/text/parse/instruction.rs
+++ b/wrausmt-format/src/text/parse/instruction.rs
@@ -29,6 +29,7 @@ impl<R: Read> Parser<R> {
             return Ok(None);
         }
 
+        let location = self.location();
         let instruction_data = instruction_by_name(name);
 
         match instruction_data {
@@ -111,6 +112,7 @@ impl<R: Read> Parser<R> {
                     name,
                     opcode: data.opcode,
                     operands,
+                    location,
                 }))
             }
             None => Err(self.err(ParseErrorKind::UnrecognizedInstruction(
@@ -223,6 +225,7 @@ impl<R: Read> Parser<R> {
         cnt: Continuation,
     ) -> Result<Instruction<Unresolved>> {
         pctx!(self, "parse folded block");
+        let location = self.location();
         let label = self.try_id()?;
         let typeuse = self.parse_type_use(super::module::FParamId::Forbidden)?;
         let instr = self.parse_instructions()?;
@@ -232,11 +235,13 @@ impl<R: Read> Parser<R> {
             name,
             opcode,
             operands,
+            location,
         })
     }
 
     fn parse_folded_if(&mut self) -> Result<Vec<Instruction<Unresolved>>> {
         pctx!(self, "parse folded if");
+        let location = self.location();
         let label = self.try_id()?;
         let typeuse = self.parse_type_use(super::module::FParamId::Forbidden)?;
         let condition = self.zero_or_more_groups(Self::try_folded_instruction)?;
@@ -263,6 +268,7 @@ impl<R: Read> Parser<R> {
             name: Id::literal("if"),
             opcode: Opcode::Normal(0x04),
             operands,
+            location,
         });
 
         Ok(unfolded)

--- a/wrausmt-format/src/text/parse/mod.rs
+++ b/wrausmt-format/src/text/parse/mod.rs
@@ -55,7 +55,7 @@ macro_rules! pctx {
     };
 }
 pub use pctx;
-use wrausmt_common::true_or::TrueOr;
+use {wrausmt_common::true_or::TrueOr, wrausmt_runtime::syntax::location::Location};
 
 // Implementation for the basic token-handling methods.
 impl<R: Read> Parser<R> {
@@ -74,6 +74,13 @@ impl<R: Read> Parser<R> {
 
     pub fn new(reader: R) -> Parser<R> {
         Parser::new_from_tokenizer(Tokenizer::new(reader))
+    }
+
+    fn location(&self) -> Location {
+        Location {
+            line: self.current.location.line,
+            pos:  self.current.location.pos,
+        }
     }
 
     pub fn assure_started(&mut self) -> Result<()> {

--- a/wrausmt-format/src/text/parse/table.rs
+++ b/wrausmt-format/src/text/parse/table.rs
@@ -35,6 +35,7 @@ impl<R: Read> Parser<R> {
 
     pub fn try_table_field(&mut self) -> Result<Option<Field<Unresolved>>> {
         pctx!(self, "try table field");
+        let location = self.location();
         if !self.try_expr_start("table")? {
             return Ok(None);
         }
@@ -68,6 +69,7 @@ impl<R: Read> Parser<R> {
                         offset:   parse_text_unresolved_instructions("i32.const 0"),
                     }),
                     elemlist,
+                    location,
                 });
                 (tabletype, elemfied)
             }
@@ -128,6 +130,7 @@ impl<R: Read> Parser<R> {
     // tableuse can be omitted, defaulting to 0.
     pub fn try_elem_field(&mut self) -> Result<Option<Field<Unresolved>>> {
         pctx!(self, "try elem field");
+        let location = self.location();
         if !self.try_expr_start("elem")? {
             return Ok(None);
         }
@@ -151,6 +154,11 @@ impl<R: Read> Parser<R> {
             ModeEntry::Passive
         };
         self.expect_close()?;
-        Ok(Some(Field::Elem(ElemField { id, mode, elemlist })))
+        Ok(Some(Field::Elem(ElemField {
+            id,
+            mode,
+            elemlist,
+            location,
+        })))
     }
 }

--- a/wrausmt-format/src/text/resolve.rs
+++ b/wrausmt-format/src/text/resolve.rs
@@ -208,6 +208,7 @@ impl Resolve<Instruction<Resolved>> for Instruction<Unresolved> {
             name:     self.name,
             opcode:   self.opcode,
             operands: self.operands.resolve(ic)?,
+            location: self.location,
         })
     }
 }
@@ -322,6 +323,7 @@ impl Resolve<GlobalField<UncompiledExpr<Resolved>>> for GlobalField<UncompiledEx
             exports:    self.exports,
             globaltype: self.globaltype,
             init:       self.init.resolve(ic)?,
+            location:   self.location,
         })
     }
 }
@@ -345,6 +347,7 @@ impl Resolve<ElemField<Resolved, UncompiledExpr<Resolved>>>
             id:       self.id,
             mode:     self.mode.resolve(ic)?,
             elemlist: self.elemlist.resolve(ic)?,
+            location: self.location,
         })
     }
 }
@@ -398,6 +401,7 @@ impl Resolve<DataField<Resolved, UncompiledExpr<Resolved>>>
             id: self.id,
             data: self.data,
             init,
+            location: self.location,
         })
     }
 }
@@ -583,6 +587,7 @@ impl Resolve<FuncField<Resolved, UncompiledExpr<Resolved>>>
             typeuse: TypeUse::ByIndex(typeuse.index().clone()),
             locals: self.locals,
             body,
+            location: self.location,
         })
     }
 }

--- a/wrausmt-runtime/src/syntax/mod.rs
+++ b/wrausmt-runtime/src/syntax/mod.rs
@@ -14,6 +14,7 @@ pub use indices::{
     Resolved, ResolvedState, TableIndex, TypeIndex, Unresolved,
 };
 use {
+    self::location::Location,
     std::{
         borrow::Cow,
         fmt::{self, Debug},
@@ -422,35 +423,27 @@ impl std::fmt::Debug for TypeField {
 // func := (func id? (import <modname> <name>) <typeuse>)
 #[derive(PartialEq)]
 pub struct FuncField<R: ResolvedState, E> {
-    pub id:      Option<Id>,
-    pub exports: Vec<String>,
-    pub typeuse: TypeUse<R>,
-    pub locals:  Vec<Local>,
-    pub body:    E,
+    pub id:       Option<Id>,
+    pub exports:  Vec<String>,
+    pub typeuse:  TypeUse<R>,
+    pub locals:   Vec<Local>,
+    pub body:     E,
+    pub location: Location,
 }
 
 impl Default for FuncField<Unresolved, UncompiledExpr<Unresolved>> {
     fn default() -> Self {
         Self {
-            id:      Default::default(),
-            exports: Default::default(),
-            typeuse: Default::default(),
-            locals:  Default::default(),
-            body:    Default::default(),
+            id:       Default::default(),
+            exports:  Default::default(),
+            typeuse:  Default::default(),
+            locals:   Default::default(),
+            body:     Default::default(),
+            location: Location { line: 0, pos: 0 },
         }
     }
 }
-impl FuncField<Resolved, UncompiledExpr<Resolved>> {
-    pub fn simple(body: UncompiledExpr<Resolved>) -> FuncField<Resolved, UncompiledExpr<Resolved>> {
-        FuncField {
-            id: None,
-            exports: Vec::new(),
-            typeuse: TypeUse::ByIndex(Index::unnamed(0)),
-            locals: Vec::new(),
-            body,
-        }
-    }
-}
+
 impl<R: ResolvedState, E: Debug> std::fmt::Debug for FuncField<R, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "(func")?;
@@ -519,6 +512,7 @@ pub struct GlobalField<E> {
     pub exports:    Vec<String>,
     pub globaltype: GlobalType,
     pub init:       E,
+    pub location:   Location,
 }
 
 impl<E: Debug> fmt::Debug for GlobalField<E> {
@@ -605,6 +599,7 @@ pub struct Instruction<R: ResolvedState> {
     pub name:     Id,
     pub opcode:   Opcode,
     pub operands: Operands<R>,
+    pub location: Location,
 }
 
 impl std::fmt::Display for Opcode {
@@ -722,6 +717,7 @@ pub struct ElemField<R: ResolvedState, E> {
     pub id:       Option<Id>,
     pub mode:     ModeEntry<R, E>,
     pub elemlist: ElemList<E>,
+    pub location: Location,
 }
 
 #[derive(Debug, PartialEq)]
@@ -736,7 +732,8 @@ pub struct DataInit<R: ResolvedState, E> {
 // memuse := (memory <memidx>)
 #[derive(Debug, PartialEq)]
 pub struct DataField<R: ResolvedState, E> {
-    pub id:   Option<Id>,
-    pub data: Box<[u8]>,
-    pub init: Option<DataInit<R, E>>,
+    pub id:       Option<Id>,
+    pub data:     Box<[u8]>,
+    pub init:     Option<DataInit<R, E>>,
+    pub location: Location,
 }


### PR DESCRIPTION
It's a large-ish change, but it's mainly adding location fields to a few key
syntax structs, and then updating the plumbing to populate and propagate them.