### PR TITLE
Enable validation for all spec tests

### DIFF
--- a/tests-integration/tests/spec/mod.rs
+++ b/tests-integration/tests/spec/mod.rs
@@ -50,7 +50,7 @@ macro_rules! spectest {
                 RunConfig {
                     runset: $runset,
                     validation_mode: $vmode,
-                    failures_to_ignore: GLOBAL_FAILURES_TO_IGNORE
+                    failures_to_ignore: GLOBAL_FAILURES_TO_IGNORE,
                 }
             )
         }
@@ -59,9 +59,9 @@ macro_rules! spectest {
         spectest!($name; val:$vmode; [RunSet::All]);
     };
     ($name:ident; [$runset:expr]) => {
-        spectest!($name; val:ValidationMode::Warn; [$runset]);
+        spectest!($name; val:ValidationMode::Fail; [$runset]);
     };
-    ($name:ident) => { spectest!($name; val: ValidationMode::Warn; [RunSet::All]); };
+    ($name:ident) => { spectest!($name; val: ValidationMode::Fail; [RunSet::All]); };
 }
 
 #[allow(unused_macros)]

--- a/tests-integration/tests/validation/data/validation.wat
+++ b/tests-integration/tests/validation/data/validation.wat
@@ -177,6 +177,6 @@
     (table.get $t2 (local.get $i))
   )
   (func (export "set-funcref") (param $i i32) (param funcref)
-    (table.set $t3 (local.get 1) (local.get $i))
+    (table.set $t3 (local.get $i) (local.get 1))
   )
 )

--- a/wrausmt-format/src/compiler/validation/mod.rs
+++ b/wrausmt-format/src/compiler/validation/mod.rs
@@ -97,7 +97,7 @@ type KindResult<T> = std::result::Result<T, ValidationErrorKind>;
 /// Type representations during validation.
 ///
 /// [Spec]: https://webassembly.github.io/spec/core/appendix/algorithm.html#data-structures
-#[derive(Debug, Default, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub enum ValidationType {
     #[default]
     Unknown,

--- a/wrausmt-format/src/compiler/validation/stacks/ctrl_stack.rs
+++ b/wrausmt-format/src/compiler/validation/stacks/ctrl_stack.rs
@@ -32,8 +32,9 @@ impl CtrlStack {
             .ok_or(ValidationErrorKind::CtrlStackUnderflow)
     }
 
-    pub fn push(&mut self, frame: CtrlFrame) {
+    pub fn push(&mut self, frame: CtrlFrame) -> &CtrlFrame {
         self.frames.push(frame);
+        self.frames.last().unwrap()
     }
 
     pub fn pop(&mut self) -> Result<CtrlFrame> {

--- a/wrausmt-format/src/text/parse/table.rs
+++ b/wrausmt-format/src/text/parse/table.rs
@@ -107,10 +107,10 @@ impl<R: Read> Parser<R> {
         allow_bare_funcidx: bool,
     ) -> Result<ElemList<UncompiledExpr<Unresolved>>> {
         pctx!(self, "try elemlist");
-        let _reftype = self.try_reftype()?;
-        let items = self.zero_or_more(Self::try_item_expression)?;
-        if !items.is_empty() {
-            return Ok(ElemList::func(items));
+        let reftype = self.try_reftype()?;
+        if let Some(reftype) = reftype {
+            let items = self.zero_or_more(Self::try_item_expression)?;
+            return Ok(ElemList { reftype, items });
         }
 
         if self.take_keyword_if(|kw| kw == "func")?.is_some() || allow_bare_funcidx {

--- a/wrausmt-runtime/src/syntax/mod.rs
+++ b/wrausmt-runtime/src/syntax/mod.rs
@@ -665,7 +665,11 @@ impl<R: ResolvedState> std::fmt::Display for Operands<R> {
 
 impl<R: ResolvedState> std::fmt::Debug for Instruction<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({}({}) {})", self.name, self.opcode, self.operands)
+        write!(
+            f,
+            "({}({}) {}) ({}:{})",
+            self.name, self.opcode, self.operands, self.location.line, self.location.pos
+        )
     }
 }
 


### PR DESCRIPTION
Validation is succeeding for all *positive* cases now.

(There's still some work to get the assert_invalid tests working)

Fixed the following validation issues:
* table.set params were swapped
* Made some types copy.clonable where it made sense
* Fix br_if validation -- not always unreachable
* Fix br_table validation -- push back what was popped, not just the frame
  types (so unknowns get pushed back)
* Fix select validation logic for unknown values.
* Fix a few numeric op param type typos
* ref_is_null should handle unknown types
* memory_copy/memory_fill checked datas instead of memories
* pop_vals should reverse the returned result
* elem_list parsing should handle all ref types not just func