### PR TITLE
Properly validate constant expressions

### DIFF
--- a/wrausmt-format/src/compiler/validation/mod.rs
+++ b/wrausmt-format/src/compiler/validation/mod.rs
@@ -35,6 +35,8 @@ pub enum ValidationErrorKind {
         actual: ValidationType,
     },
     ImmutableGlobal,
+    InvalidConstantGlobal,
+    InvalidConstantInstruction,
     UnusedValues,
     UnknownLocal(Index<Resolved, LocalIndex>),
     AlignmentTooLarge(u32),
@@ -197,6 +199,15 @@ impl ModuleContext {
         }
     }
 }
+
+/// Differentiate between constant and normal expressions.
+pub enum ExpressionType {
+    /// A normal expression allowing all instructions
+    Normal,
+    /// A constant expression allowing only the instructions defined by the spec
+    /// for constant expressions.
+    Constant,
+}
 /// The Validation context and implementation.
 ///
 /// [Spec]: https://webassembly.github.io/spec/core/appendix/algorithm.html
@@ -210,6 +221,8 @@ pub struct Validation<'a> {
     pub localtypes: Vec<ValueType>,
 
     stacks: Stacks,
+
+    expression_type: ExpressionType,
 }
 
 impl<'a> Validation<'a> {
@@ -218,6 +231,7 @@ impl<'a> Validation<'a> {
         module: &ModuleContext,
         localtypes: Vec<ValueType>,
         resulttypes: Vec<ValueType>,
+        expression_type: ExpressionType,
     ) -> Validation {
         let stacks = Stacks::new();
         let mut val = Validation {
@@ -225,6 +239,7 @@ impl<'a> Validation<'a> {
             module,
             localtypes,
             stacks,
+            expression_type,
         };
 
         val.stacks

--- a/wrausmt-format/src/text/mod.rs
+++ b/wrausmt-format/src/text/mod.rs
@@ -1,9 +1,5 @@
 use {
-    self::{
-        module_builder::ModuleIdentifiers,
-        parse::Parser,
-        resolve::{ResolutionContext, Resolve},
-    },
+    self::parse::Parser,
     super::text::parse::error::Result,
     std::io::Read,
     wrausmt_runtime::syntax::{Module, Resolved, UncompiledExpr, Unresolved},
@@ -24,25 +20,6 @@ pub fn parse_wast_data(
 ) -> Result<Module<Resolved, UncompiledExpr<Resolved>>> {
     let mut parser = Parser::new(reader);
     parser.parse_full_module()
-}
-
-/// This is for internal use for very simple inline expressions that get
-/// inserted during compilation. It's very quick and dirty, and is hard to debug
-/// if something goes wrong.
-/// If parsing into a resolved instruction, no named indices can be used, or
-/// anything else that gets worked out at resolution time.
-/// This is suitable for constant expressions.
-pub(crate) fn parse_text_resolved_instructions(data: &str) -> UncompiledExpr<Resolved> {
-    let expr = parse_text_unresolved_instructions(data);
-    let mut types = Vec::new();
-    let module_identifiers = ModuleIdentifiers::default();
-    let mut rc = ResolutionContext {
-        types:        &mut types,
-        modulescope:  &module_identifiers,
-        localindices: Vec::new(),
-        labelindices: Vec::new(),
-    };
-    expr.resolve(&mut rc).unwrap()
 }
 
 pub(crate) fn parse_text_unresolved_instructions(data: &str) -> UncompiledExpr<Unresolved> {


### PR DESCRIPTION
Fixes:
* Change validate else/end pattern so they don't emit instructions. We need to
  "end" the constant expression to validate its result, but end is not an
  allowed instruction.
* Change the compilation of the table and memory init end instructions. They
  use "non-constant" instructions, so rather than updating the hack to work,
  just hand-roll the simple instructions.
* Add the concept of ExpressionType, and for constant expressions, only allow
  the relevant instructions.
