### PR TITLE
Create a constant expression compiler/validator

### DIFF
--- a/wrausmt-format/src/compiler/const_expression.rs
+++ b/wrausmt-format/src/compiler/const_expression.rs
@@ -1,0 +1,116 @@
+use {
+    super::validation::{ModuleContext, ValidationType},
+    crate::{compiler::validation::KindResult, ValidationErrorKind},
+    wrausmt_common::true_or::TrueOr,
+    wrausmt_runtime::{
+        instructions::opcodes,
+        syntax::{
+            types::{NumType, RefType, ValueType},
+            CompiledExpr, Instruction, Operands, Resolved, UncompiledExpr,
+        },
+    },
+};
+
+macro_rules! instr {
+    ($opcode:pat => $operands:pat) => {
+        Instruction {
+            opcode: $opcode,
+            operands: $operands,
+            ..
+        }
+    };
+}
+
+/// A separate emitter/validater for constant expressions.
+/// Rather than including branching logic in the primary emitter/validator, it's
+/// much clearer to create a parallel implementation here.
+///
+/// There are some different validation conditions that don't apply to the main
+/// validator (imported globals only, const globals only, ref funcs can be
+/// updated).
+pub fn compile_const_expr(
+    expr: &UncompiledExpr<Resolved>,
+    module: &ModuleContext,
+    expect_type: ValueType,
+) -> KindResult<CompiledExpr> {
+    let mut out = Vec::<u8>::new();
+    let mut stack = Vec::<ValueType>::new();
+    for instr in &expr.instr {
+        validate_and_emit_instr(instr, &mut out, module, &mut stack)?;
+    }
+
+    (stack == [expect_type]).true_or(ValidationErrorKind::TypeMismatch {
+        actual: ValidationType::Value(*stack.first().unwrap_or(&ValueType::Void)),
+        expect: ValidationType::Value(expect_type),
+    })?;
+
+    Ok(CompiledExpr {
+        instr: out.into_boxed_slice(),
+    })
+}
+
+fn validate_and_emit_instr(
+    instr: &Instruction<Resolved>,
+    out: &mut Vec<u8>,
+    module: &ModuleContext,
+    stack: &mut Vec<ValueType>,
+) -> KindResult<()> {
+    out.extend(instr.opcode.bytes());
+    match instr {
+        instr!(opcodes::I32_CONST => Operands::I32(v)) => {
+            stack.push(NumType::I32.into());
+
+            let bytes = &v.to_le_bytes()[..];
+            out.extend(bytes);
+        }
+        instr!(opcodes::I64_CONST => Operands::I64(v)) => {
+            stack.push(NumType::I64.into());
+
+            let bytes = &v.to_le_bytes()[..];
+            out.extend(bytes);
+        }
+        instr!(opcodes::F32_CONST => Operands::F32(v)) => {
+            stack.push(NumType::F32.into());
+
+            let bytes = &v.to_bits().to_le_bytes()[..];
+            out.extend(bytes);
+        }
+        instr!(opcodes::F64_CONST => Operands::F64(v)) => {
+            stack.push(NumType::F64.into());
+
+            let bytes = &v.to_bits().to_le_bytes()[..];
+            out.extend(bytes);
+        }
+        instr!(opcodes::REF_NULL => Operands::HeapType(ht)) => {
+            stack.push((*ht).into());
+
+            let htbyte = match ht {
+                RefType::Func => 0x70,
+                RefType::Extern => 0x6F,
+            };
+            out.push(htbyte);
+        }
+        instr!(opcodes::REF_FUNC => Operands::FuncIndex(fi)) => {
+            ((fi.value() as usize) < module.funcs.len())
+                .true_or(ValidationErrorKind::UnknownFunc)?;
+            stack.push(RefType::Func.into());
+
+            let bytes = &fi.value().to_le_bytes()[..];
+            out.extend(bytes);
+        }
+        instr!(opcodes::GLOBAL_GET => Operands::GlobalIndex(gi)) => {
+            let global = module
+                .globals
+                .get(gi.value() as usize)
+                .ok_or(ValidationErrorKind::UnknownGlobal)?;
+            (global.imported && !global.globaltype.mutable)
+                .true_or(ValidationErrorKind::InvalidConstantGlobal)?;
+            stack.push(global.globaltype.valtype);
+
+            let bytes = &gi.value().to_le_bytes()[..];
+            out.extend(bytes);
+        }
+        _ => Err(ValidationErrorKind::InvalidConstantInstruction)?,
+    };
+    Ok(())
+}

--- a/wrausmt-format/src/compiler/validation/mod.rs
+++ b/wrausmt-format/src/compiler/validation/mod.rs
@@ -131,8 +131,8 @@ impl From<syntax::FunctionType> for FunctionType {
 
 #[derive(Clone, Debug)]
 pub struct GlobalValidationType {
-    globaltype: GlobalType,
-    imported:   bool,
+    pub globaltype: GlobalType,
+    pub imported:   bool,
 }
 
 /// A simple struct containing the type information needed for validation of the
@@ -227,14 +227,6 @@ impl ModuleContext {
     }
 }
 
-/// Differentiate between constant and normal expressions.
-pub enum ExpressionType {
-    /// A normal expression allowing all instructions
-    Normal,
-    /// A constant expression allowing only the instructions defined by the spec
-    /// for constant expressions.
-    Constant,
-}
 /// The Validation context and implementation.
 ///
 /// [Spec]: https://webassembly.github.io/spec/core/appendix/algorithm.html
@@ -248,8 +240,6 @@ pub struct Validation<'a> {
     pub localtypes: Vec<ValueType>,
 
     stacks: Stacks,
-
-    expression_type: ExpressionType,
 }
 
 impl<'a> Validation<'a> {
@@ -258,7 +248,6 @@ impl<'a> Validation<'a> {
         module: &ModuleContext,
         localtypes: Vec<ValueType>,
         resulttypes: Vec<ValueType>,
-        expression_type: ExpressionType,
     ) -> Validation {
         let stacks = Stacks::new();
         let mut val = Validation {
@@ -266,7 +255,6 @@ impl<'a> Validation<'a> {
             module,
             localtypes,
             stacks,
-            expression_type,
         };
 
         val.stacks

--- a/wrausmt-format/src/compiler/validation/ops.rs
+++ b/wrausmt-format/src/compiler/validation/ops.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        ExpressionType, FunctionType, KindResult as Result, Validation, ValidationErrorKind,
-        ValidationMode,
-    },
+    super::{FunctionType, KindResult as Result, Validation, ValidationErrorKind, ValidationMode},
     crate::compiler::validation::ValidationType,
     wrausmt_common::true_or::TrueOr,
     wrausmt_runtime::{
@@ -128,33 +125,6 @@ impl<'a> Validation<'a> {
             .copied()
     }
 
-    fn validate_instruction_allowed(&mut self, instr: &Instruction<Resolved>) -> Result<()> {
-        match self.expression_type {
-            ExpressionType::Normal => Ok(()),
-            ExpressionType::Constant => match instr {
-                instr!(opcodes::I32_CONST => Operands::I32(_))
-                | instr!(opcodes::I64_CONST => Operands::I64(_))
-                | instr!(opcodes::F32_CONST => Operands::F32(_))
-                | instr!(opcodes::F64_CONST => Operands::F64(_))
-                | instr!(opcodes::REF_NULL => Operands::HeapType(_))
-                | instr!(opcodes::REF_FUNC => Operands::FuncIndex(_)) => Ok(()),
-                instr!(opcodes::GLOBAL_GET => Operands::GlobalIndex(idx)) => {
-                    self.module
-                        .globals
-                        .get(idx.value() as usize)
-                        .map(|g| g.imported && !g.globaltype.mutable)
-                        .ok_or(ValidationErrorKind::UnknownGlobal)?
-                        .true_or(ValidationErrorKind::InvalidConstantGlobal)?;
-                    Ok(())
-                }
-                _ => {
-                    println!("INVALID {:?}", instr);
-                    Err(ValidationErrorKind::InvalidConstantInstruction)?
-                }
-            },
-        }
-    }
-
     pub fn validate_end(&mut self) -> Result<()> {
         self.error_for_mode(|s| {
             let frame = s.stacks.pop_ctrl()?;
@@ -175,7 +145,6 @@ impl<'a> Validation<'a> {
 
     fn validation_result(&mut self, instr: &Instruction<Resolved>) -> Result<()> {
         println!("VALIDATION {instr:?}");
-        self.validate_instruction_allowed(instr)?;
 
         match instr {
             instr!(opcodes::UNREACHABLE) => self.stacks.unreachable(),

--- a/wrausmt-runtime/src/syntax/mod.rs
+++ b/wrausmt-runtime/src/syntax/mod.rs
@@ -15,6 +15,7 @@ pub use indices::{
 };
 use {
     self::location::Location,
+    crate::instructions::op_consts,
     std::{
         borrow::Cow,
         fmt::{self, Debug},
@@ -596,6 +597,16 @@ pub enum Opcode {
     Extended(u8),
     // 0xFD-prefix instructions
     Simd(u8),
+}
+
+impl Opcode {
+    pub fn bytes(&self) -> Vec<u8> {
+        match self {
+            Opcode::Normal(o) => vec![*o],
+            Opcode::Extended(o) => vec![op_consts::EXTENDED_PREFIX, *o],
+            Opcode::Simd(o) => vec![op_consts::SIMD_PREFIX, *o],
+        }
+    }
 }
 
 #[derive(Clone, PartialEq)]


### PR DESCRIPTION
Rather than flagging/branching the primary compiler/validator, it's much
simpler and clearer to just create a separate const expression emitter for the
6 supported instructions.

Also make a method on Opcode that emits the proper bytes, so we can use it in
both emitters.
