### PR TITLE
Enable start function and function ref invalid tests

### DIFF
--- a/tests-integration/src/spec/error_mappings.rs
+++ b/tests-integration/src/spec/error_mappings.rs
@@ -186,6 +186,7 @@ fn matches_validation_error(failure: &str, err: &ValidationError) -> bool {
         ValidationErrorKind::InvalidConstantGlobal => failure == "unknown global",
         ValidationErrorKind::ImmutableGlobal => failure == "global is immutable",
         ValidationErrorKind::TypeMismatch { .. } => failure == "type mismatch",
+        ValidationErrorKind::UndeclaredFunctionRef => failure == "undeclared function reference",
         ValidationErrorKind::UnknownData => failure.starts_with("unknown data segment"),
         ValidationErrorKind::UnknownElem => failure.starts_with("unknown elem segment"),
         ValidationErrorKind::UnknownFunc => failure.starts_with("unknown func"),
@@ -197,6 +198,7 @@ fn matches_validation_error(failure: &str, err: &ValidationError) -> bool {
         ValidationErrorKind::UnknownType => failure == "unknown type",
         ValidationErrorKind::UnusedValues => failure == "type mismatch",
         ValidationErrorKind::ValStackUnderflow => failure == "type mismatch",
+        ValidationErrorKind::WrongStartFunctionType => failure == "start function",
         ValidationErrorKind::WrongTableType => failure == "wrong table type",
         _ => false,
     }

--- a/tests-integration/tests/spec/mod.rs
+++ b/tests-integration/tests/spec/mod.rs
@@ -16,8 +16,6 @@ const GLOBAL_FAILURES_TO_IGNORE: &[&str] = &[
     "memory size must be at most 65536 pages (4GiB)",
     "multiple memories",
     "size minimum must not be greater than maximum",
-    "start function",
-    "undeclared function reference",
 ];
 // To regenerate the spectest! lines below using the transform this macro
 // expects: "".join(["spectest!(r#{});

--- a/wrausmt-format/src/compiler/validation/ops.rs
+++ b/wrausmt-format/src/compiler/validation/ops.rs
@@ -566,6 +566,8 @@ impl<'a> Validation<'a> {
             instr!(opcodes::REF_FUNC => Operands::FuncIndex(idx)) => {
                 ((idx.value() as usize) < self.module.funcs.len())
                     .true_or(ValidationErrorKind::UnknownFunc)?;
+                (self.module.funcrefs.contains(idx))
+                    .true_or(ValidationErrorKind::UndeclaredFunctionRef)?;
                 self.stacks.push_val(FUNC);
                 Ok(())
             }


### PR DESCRIPTION
We need to track function ref declarations in constant expressions and export
declarations.