### PR TITLE
Add typesafety for module validation

### DIFF
--- a/tests-integration/src/spec/format.rs
+++ b/tests-integration/src/spec/format.rs
@@ -11,7 +11,7 @@ use {
             self as modulesyntax,
             location::Location,
             types::{NumType, RefType},
-            Id, Resolved, UncompiledExpr,
+            Id, Resolved, UncompiledExpr, Unvalidated,
         },
     },
 };
@@ -489,7 +489,7 @@ pub struct CmdEntry {
 /// ```
 #[derive(Debug)]
 pub enum Module {
-    Module(modulesyntax::Module<Resolved, UncompiledExpr<Resolved>>),
+    Module(modulesyntax::Module<Resolved, Unvalidated, UncompiledExpr<Resolved>>),
     Binary(Option<Id>, Vec<WasmString>),
     Quote(Option<Id>, Vec<WasmString>),
 }

--- a/wrausmt-format/src/binary/exports.rs
+++ b/wrausmt-format/src/binary/exports.rs
@@ -4,7 +4,7 @@ use {
         BinaryParser, ParserReader,
     },
     crate::{binary::read_with_location::Locate, pctx},
-    wrausmt_runtime::syntax::{ExportDesc, ExportField, Resolved},
+    wrausmt_runtime::syntax::{ExportDesc, ExportField, Resolved, Unvalidated},
 };
 
 /// A trait to allow parsing of an exports section from something implementing
@@ -18,7 +18,9 @@ impl<R: ParserReader> BinaryParser<R> {
     /// 0x01 Table
     /// 0x02 Memory
     /// 0x03 Global
-    pub(in crate::binary) fn read_exports_section(&mut self) -> Result<Vec<ExportField<Resolved>>> {
+    pub(in crate::binary) fn read_exports_section(
+        &mut self,
+    ) -> Result<Vec<ExportField<Resolved, Unvalidated>>> {
         self.read_vec(|_, s| s.read_export_field())
     }
 
@@ -34,13 +36,13 @@ impl<R: ParserReader> BinaryParser<R> {
         }
     }
 
-    fn read_export_field(&mut self) -> Result<ExportField<Resolved>> {
+    fn read_export_field(&mut self) -> Result<ExportField<Resolved, Unvalidated>> {
         pctx!(self, "read exprt field");
         let location = self.location();
-        Ok(ExportField {
-            name: self.read_name()?,
-            exportdesc: self.read_export_desc()?,
+        Ok(ExportField::new(
+            self.read_name()?,
+            self.read_export_desc()?,
             location,
-        })
+        ))
     }
 }

--- a/wrausmt-format/src/binary/mod.rs
+++ b/wrausmt-format/src/binary/mod.rs
@@ -9,7 +9,7 @@ use {
         tracer::{TraceDropper, Tracer},
         true_or::TrueOr,
     },
-    wrausmt_runtime::syntax::{location::Location, TypeUse, UncompiledExpr},
+    wrausmt_runtime::syntax::{location::Location, TypeUse, UncompiledExpr, Unvalidated},
 };
 
 pub mod error;
@@ -52,7 +52,7 @@ pub trait ParserReader: Read + Locate {}
 impl<R: ParserReader> BinaryParser<R> {
     /// Inner parse method accepts a mutable module, so that the outer parse
     /// method can return partial module results (useful for debugging).
-    fn parse(&mut self) -> Result<Module<Resolved, UncompiledExpr<Resolved>>> {
+    fn parse(&mut self) -> Result<Module<Resolved, Unvalidated, UncompiledExpr<Resolved>>> {
         let mut module = Module::default();
 
         self.read_magic()
@@ -207,7 +207,9 @@ impl<T: ParserReader> ParserReader for BinaryParser<T> {}
 /// Attempt to interpret the data in the provided std::io:Read as a WASM binary
 /// module. If an error occurs, a ParseError will be returned containing the
 /// portion of the module that was successfully decoded.
-pub fn parse_wasm_data(src: &mut impl Read) -> Result<Module<Resolved, UncompiledExpr<Resolved>>> {
+pub fn parse_wasm_data(
+    src: &mut impl Read,
+) -> Result<Module<Resolved, Unvalidated, UncompiledExpr<Resolved>>> {
     let reader = ReadWithLocation::new(src);
     let mut parser = BinaryParser::new(reader);
     parser.parse()

--- a/wrausmt-format/src/binary/start.rs
+++ b/wrausmt-format/src/binary/start.rs
@@ -1,7 +1,7 @@
 use {
     super::{error::Result, BinaryParser, ParserReader},
     crate::{binary::read_with_location::Locate, pctx},
-    wrausmt_runtime::syntax::{Resolved, StartField},
+    wrausmt_runtime::syntax::{Resolved, StartField, Unvalidated},
 };
 
 /// Read the tables section of a binary module from a std::io::Read.
@@ -9,12 +9,11 @@ impl<R: ParserReader> BinaryParser<R> {
     /// Read a funcs section. This is just a vec(TypeIndex).
     /// The values here don't correspond to a real module section, instead they
     /// correlate with the rest of the function data in the code section.
-    pub(in crate::binary) fn read_start_section(&mut self) -> Result<StartField<Resolved>> {
+    pub(in crate::binary) fn read_start_section(
+        &mut self,
+    ) -> Result<StartField<Resolved, Unvalidated>> {
         pctx!(self, "read start");
         let location = self.location();
-        Ok(StartField {
-            idx: self.read_index_use()?,
-            location,
-        })
+        Ok(StartField::new(self.read_index_use()?, location))
     }
 }

--- a/wrausmt-format/src/compiler/validation/mod.rs
+++ b/wrausmt-format/src/compiler/validation/mod.rs
@@ -12,7 +12,7 @@ use {
             location::Location,
             types::{GlobalType, MemType, RefType, TableType, ValueType},
             FuncIndex, ImportDesc, Index, Instruction, LocalIndex, Module, Resolved,
-            UncompiledExpr,
+            UncompiledExpr, Unvalidated,
         },
     },
 };
@@ -165,7 +165,7 @@ impl ModuleContext {
     /// Create a new [`ModuleContext`] for validation, using the type
     /// information in the provided [`Module`]. The informatin will be copied
     /// out of the module.
-    pub fn new(module: &Module<Resolved, UncompiledExpr<Resolved>>) -> Result<Self> {
+    pub fn new(module: &Module<Resolved, Unvalidated, UncompiledExpr<Resolved>>) -> Result<Self> {
         let mut funcs: Vec<FunctionType> = Vec::new();
         let mut tables: Vec<TableType> = Vec::new();
         let mut mems: Vec<MemType> = Vec::new();

--- a/wrausmt-format/src/text/mod.rs
+++ b/wrausmt-format/src/text/mod.rs
@@ -2,7 +2,7 @@ use {
     self::parse::Parser,
     super::text::parse::error::Result,
     std::io::Read,
-    wrausmt_runtime::syntax::{Module, Resolved, UncompiledExpr, Unresolved},
+    wrausmt_runtime::syntax::{Module, Resolved, UncompiledExpr, Unresolved, Unvalidated},
 };
 
 pub mod lex;
@@ -17,7 +17,7 @@ pub mod string;
 
 pub fn parse_wast_data(
     reader: &mut impl Read,
-) -> Result<Module<Resolved, UncompiledExpr<Resolved>>> {
+) -> Result<Module<Resolved, Unvalidated, UncompiledExpr<Resolved>>> {
     let mut parser = Parser::new(reader);
     parser.parse_full_module()
 }

--- a/wrausmt-format/src/text/parse/table.rs
+++ b/wrausmt-format/src/text/parse/table.rs
@@ -5,7 +5,7 @@ use {
     wrausmt_runtime::syntax::{
         types::{RefType, TableType},
         ElemField, ElemList, FuncIndex, ImportDesc, ImportField, ModeEntry, TableField,
-        TablePosition, TableUse, UncompiledExpr, Unresolved,
+        TablePosition, TableUse, UncompiledExpr, Unresolved, Unvalidated,
     },
 };
 
@@ -33,7 +33,7 @@ impl<R: Read> Parser<R> {
         Ok(ElemList::func(items))
     }
 
-    pub fn try_table_field(&mut self) -> Result<Option<Field<Unresolved>>> {
+    pub fn try_table_field(&mut self) -> Result<Option<Field<Unresolved, Unvalidated>>> {
         pctx!(self, "try table field");
         let location = self.location();
         if !self.try_expr_start("table")? {
@@ -130,7 +130,7 @@ impl<R: Read> Parser<R> {
     // (<instr>) === (offset <instr>)
     // (<instr>) === (item <instr>)
     // tableuse can be omitted, defaulting to 0.
-    pub fn try_elem_field(&mut self) -> Result<Option<Field<Unresolved>>> {
+    pub fn try_elem_field(&mut self) -> Result<Option<Field<Unresolved, Unvalidated>>> {
         pctx!(self, "try elem field");
         let location = self.location();
         if !self.try_expr_start("elem")? {

--- a/wrausmt-runtime/src/runtime/instantiate.rs
+++ b/wrausmt-runtime/src/runtime/instantiate.rs
@@ -17,6 +17,7 @@ use {
             self,
             types::{FunctionType, ValueType},
             CompiledExpr, DataInit, FuncField, ImportDesc, ModeEntry, Resolved, TablePosition,
+            Validated,
         },
     },
     std::{convert::identity, rc::Rc},
@@ -28,7 +29,7 @@ impl Runtime {
     /// [syntax::Module].
     pub fn load(
         &mut self,
-        module: syntax::Module<Resolved, CompiledExpr>,
+        module: syntax::Module<Resolved, Validated, CompiledExpr>,
     ) -> Result<Rc<ModuleInstance>> {
         self.instantiate(module)
     }
@@ -124,7 +125,7 @@ impl Runtime {
     }
 
     pub fn instantiate_export(
-        ast: syntax::ExportField<Resolved>,
+        ast: syntax::ExportField<Resolved, Validated>,
         modinst: &ModuleInstance,
     ) -> ExportInstance {
         ExportInstance {
@@ -135,7 +136,7 @@ impl Runtime {
 
     fn instantiate(
         &mut self,
-        module: syntax::Module<Resolved, CompiledExpr>,
+        module: syntax::Module<Resolved, Validated, CompiledExpr>,
     ) -> Result<Rc<ModuleInstance>> {
         let mut modinst_builder = ModuleInstanceBuilder {
             types: module


### PR DESCRIPTION
Now modules (and the appropriate items in modules) have a `ValidatedState`
parameter, which is set to `Validated` after running through the validation
algorithm.
