### PR TITLE
zero_or_more_groups: Add more details to results

### DIFF
--- a/wrausmt-format/src/text/parse/combinator.rs
+++ b/wrausmt-format/src/text/parse/combinator.rs
@@ -22,13 +22,18 @@ impl<R: Read> Parser<R> {
     /// Attempts to parse a series of items using the provided parse method.
     /// The parse method should return 0 or more of the item type.
     /// Returns the results as a flattened vector of items.
-    pub fn zero_or_more_groups<T>(&mut self, parse: ParseGroupFn<Self, T>) -> Result<Vec<T>> {
+    pub fn zero_or_more_groups<T>(
+        &mut self,
+        parse: ParseGroupFn<Self, T>,
+    ) -> Result<(Vec<T>, bool)> {
         pctx!(self, "zero or more groups");
         let mut result: Vec<T> = vec![];
+        let mut any = false;
         while let Some(t) = parse(self)? {
+            any = true;
             result.extend(t);
         }
-        Ok(result)
+        Ok((result, any))
     }
 
     /// Attempts to parse a series of items using the provided parse method.

--- a/wrausmt-format/src/text/parse/module.rs
+++ b/wrausmt-format/src/text/parse/module.rs
@@ -188,14 +188,16 @@ impl<R: Read> Parser<R> {
     pub fn try_function_type(&mut self, fparam_id: FParamId) -> Result<FunctionType> {
         pctx!(self, "try function type");
         Ok(FunctionType {
-            params:  self.zero_or_more_groups(match fparam_id {
-                // Using closures makes the combinators a lot more complicated.
-                // For this use case, it's simpler to just create variants for the
-                // two types of FParam variants.
-                FParamId::Allowed => Self::try_parse_fparam_id_allowed,
-                FParamId::Forbidden => Self::try_parse_fparam_id_forbidden,
-            })?,
-            results: self.zero_or_more_groups(Self::try_parse_fresult)?,
+            params:  self
+                .zero_or_more_groups(match fparam_id {
+                    // Using closures makes the combinators a lot more complicated.
+                    // For this use case, it's simpler to just create variants for the
+                    // two types of FParam variants.
+                    FParamId::Allowed => Self::try_parse_fparam_id_allowed,
+                    FParamId::Forbidden => Self::try_parse_fparam_id_forbidden,
+                })?
+                .0,
+            results: self.zero_or_more_groups(Self::try_parse_fresult)?.0,
         })
     }
 
@@ -227,7 +229,7 @@ impl<R: Read> Parser<R> {
             })));
         }
 
-        let locals = self.zero_or_more_groups(Self::try_locals)?;
+        let (locals, _) = self.zero_or_more_groups(Self::try_locals)?;
 
         let instr = self.parse_instructions()?;
         self.expect_close()?;


### PR DESCRIPTION
We return information about whether any empty groups were consumed as well.
