### PR TITLE
Enable more invalid tests and fix them

### DIFF
--- a/tests-integration/src/spec/error_mappings.rs
+++ b/tests-integration/src/spec/error_mappings.rs
@@ -180,11 +180,19 @@ fn matches_resolve_error(failure: &str, err: &ResolveError) -> bool {
 
 fn matches_validation_error(failure: &str, err: &ValidationError) -> bool {
     match err.kind() {
+        ValidationErrorKind::AlignmentTooLarge(_) => {
+            failure == "alignment must not be larger than natural"
+        }
         ValidationErrorKind::BreakTypeMismatch => failure == "type mismatch",
+        ValidationErrorKind::DuplicateExport => failure == "duplicate export name",
         ValidationErrorKind::ExpectedNum { .. } => failure == "type mismatch",
         ValidationErrorKind::ExpectedRef { .. } => failure == "type mismatch",
         ValidationErrorKind::InvalidConstantGlobal => failure == "unknown global",
+        ValidationErrorKind::InvalidConstantInstruction => {
+            failure == "constant expression required"
+        }
         ValidationErrorKind::ImmutableGlobal => failure == "global is immutable",
+        ValidationErrorKind::MultipleMemories => failure == "multiple memories",
         ValidationErrorKind::TypeMismatch { .. } => failure == "type mismatch",
         ValidationErrorKind::UndeclaredFunctionRef => failure == "undeclared function reference",
         ValidationErrorKind::UnknownData => failure.starts_with("unknown data segment"),
@@ -196,6 +204,7 @@ fn matches_validation_error(failure: &str, err: &ValidationError) -> bool {
         ValidationErrorKind::UnknownMemory => failure.starts_with("unknown memory"),
         ValidationErrorKind::UnknownTable => failure.starts_with("unknown table"),
         ValidationErrorKind::UnknownType => failure == "unknown type",
+        ValidationErrorKind::UnsupportedSelect => failure == "invalid result arity",
         ValidationErrorKind::UnusedValues => failure == "type mismatch",
         ValidationErrorKind::ValStackUnderflow => failure == "type mismatch",
         ValidationErrorKind::WrongStartFunctionType => failure == "start function",

--- a/tests-integration/tests/spec/mod.rs
+++ b/tests-integration/tests/spec/mod.rs
@@ -8,13 +8,7 @@ use {
 };
 
 const GLOBAL_FAILURES_TO_IGNORE: &[&str] = &[
-    "alignment must not be larger than natural",
-    "constant expression required",
-    "duplicate export name",
-    "global is immutable",
-    "invalid result arity",
     "memory size must be at most 65536 pages (4GiB)",
-    "multiple memories",
     "size minimum must not be greater than maximum",
 ];
 // To regenerate the spectest! lines below using the transform this macro

--- a/wrausmt-format/src/compiler/const_expression.rs
+++ b/wrausmt-format/src/compiler/const_expression.rs
@@ -106,8 +106,9 @@ fn validate_and_emit_instr(
                 .globals
                 .get(gi.value() as usize)
                 .ok_or(ValidationErrorKind::UnknownGlobal)?;
-            (global.imported && !global.globaltype.mutable)
-                .true_or(ValidationErrorKind::InvalidConstantGlobal)?;
+            (global.imported).true_or(ValidationErrorKind::InvalidConstantGlobal)?;
+            (!global.globaltype.mutable)
+                .true_or(ValidationErrorKind::InvalidConstantInstruction)?;
             stack.push(global.globaltype.valtype);
 
             let bytes = &gi.value().to_le_bytes()[..];


### PR DESCRIPTION
* Update needed error mappings
* Return proper error for mutable global in constexpr
* Check for duplicate export names
* Check for multiple memories
