### PR TITLE
Propertly implement blocktypes

### DIFF
--- a/wrausmt-format/src/binary/code.rs
+++ b/wrausmt-format/src/binary/code.rs
@@ -265,12 +265,12 @@ impl<R: ParserReader> BinaryParser<R> {
                 syntax::Operands::None
             }
             Operands::Block => {
-                let bt = self.read_type_use()?;
+                let bt = self.read_blocktype()?;
                 let expr = self.read_expr(data_indices_ok)?;
                 syntax::Operands::Block(None, bt, expr, Continuation::End)
             }
             Operands::Loop => {
-                let bt = self.read_type_use()?;
+                let bt = self.read_blocktype()?;
                 let expr = self.read_expr(data_indices_ok)?;
                 syntax::Operands::Block(None, bt, expr, Continuation::Start)
             }

--- a/wrausmt-format/src/compiler/const_expression.rs
+++ b/wrausmt-format/src/compiler/const_expression.rs
@@ -41,7 +41,11 @@ pub fn compile_const_expr(
     }
 
     (stack == [expect_type]).true_or(ValidationErrorKind::TypeMismatch {
-        actual: ValidationType::Value(*stack.first().unwrap_or(&ValueType::Void)),
+        actual: ValidationType::Value(
+            *stack
+                .first()
+                .ok_or(ValidationErrorKind::ValStackUnderflow)?,
+        ),
         expect: ValidationType::Value(expect_type),
     })?;
 

--- a/wrausmt-format/src/text/parse/instruction.rs
+++ b/wrausmt-format/src/text/parse/instruction.rs
@@ -133,13 +133,13 @@ impl<R: Read> Parser<R> {
     fn parse_plain_block(&mut self, cnt: Continuation) -> Result<syntax::Operands<Unresolved>> {
         pctx!(self, "parse plain block");
         let label = self.try_id()?;
-        let typeuse = self.parse_type_use(super::module::FParamId::Forbidden)?;
+        let blocktype = self.parse_block_type()?;
         let instr = self.parse_instructions()?;
         self.expect_plain_end(&label)?;
 
         Ok(syntax::Operands::Block(
             label,
-            typeuse,
+            blocktype,
             UncompiledExpr { instr },
             cnt,
         ))
@@ -149,7 +149,7 @@ impl<R: Read> Parser<R> {
         pctx!(self, "parse plain if operands");
         let label = self.try_id()?;
 
-        let typeuse = self.parse_type_use(super::module::FParamId::Forbidden)?;
+        let blocktype = self.parse_block_type()?;
 
         let thengroup = self.parse_instructions()?;
 
@@ -165,7 +165,7 @@ impl<R: Read> Parser<R> {
 
         Ok(syntax::Operands::If(
             label,
-            typeuse,
+            blocktype,
             UncompiledExpr { instr: thengroup },
             UncompiledExpr { instr: elsegroup },
         ))
@@ -228,10 +228,10 @@ impl<R: Read> Parser<R> {
         pctx!(self, "parse folded block");
         let location = self.location();
         let label = self.try_id()?;
-        let typeuse = self.parse_type_use(super::module::FParamId::Forbidden)?;
+        let blocktype = self.parse_block_type()?;
         let instr = self.parse_instructions()?;
         self.expect_close()?;
-        let operands = syntax::Operands::Block(label, typeuse, UncompiledExpr { instr }, cnt);
+        let operands = syntax::Operands::Block(label, blocktype, UncompiledExpr { instr }, cnt);
         Ok(Instruction {
             name,
             opcode,
@@ -244,7 +244,7 @@ impl<R: Read> Parser<R> {
         pctx!(self, "parse folded if");
         let location = self.location();
         let label = self.try_id()?;
-        let typeuse = self.parse_type_use(super::module::FParamId::Forbidden)?;
+        let blocktype = self.parse_block_type()?;
         let condition = self
             .zero_or_more_groups(Self::try_folded_instruction)?
             .result;
@@ -265,7 +265,7 @@ impl<R: Read> Parser<R> {
         };
 
         self.expect_close()?;
-        let operands = syntax::Operands::If(label, typeuse, thexpr, elexpr);
+        let operands = syntax::Operands::If(label, blocktype, thexpr, elexpr);
 
         unfolded.push(Instruction {
             name: Id::literal("if"),

--- a/wrausmt-runtime/src/runtime/values.rs
+++ b/wrausmt-runtime/src/runtime/values.rs
@@ -34,7 +34,6 @@ use {
 pub enum Value {
     Num(Num),
     Ref(Ref),
-    Void,
 }
 
 /// A numeric value that a WebAssembly program can manipulate. [Spec][Spec]
@@ -78,7 +77,6 @@ impl Value {
         match self {
             Value::Num(n) => ValueType::Num(n.numtype()),
             Value::Ref(r) => ValueType::Ref(r.reftype()),
-            Value::Void => ValueType::Void,
         }
     }
 
@@ -143,7 +141,6 @@ impl ValueType {
         match &self {
             ValueType::Num(n) => Value::Num(n.default()),
             ValueType::Ref(r) => Value::Ref(r.default()),
-            ValueType::Void => Value::Void,
         }
     }
 }

--- a/wrausmt-runtime/src/syntax/mod.rs
+++ b/wrausmt-runtime/src/syntax/mod.rs
@@ -315,10 +315,11 @@ pub enum TypeUse<R: ResolvedState> {
     },
 }
 
-impl<R: ResolvedState> Default for TypeUse<R> {
-    fn default() -> Self {
-        TypeUse::ByIndex(Index::unnamed(0))
-    }
+#[derive(Clone, Debug, PartialEq)]
+pub enum BlockType<R: ResolvedState> {
+    Void,
+    SingleResult(ValueType),
+    TypeUse(TypeUse<R>),
 }
 
 impl TypeUse<Resolved> {
@@ -340,15 +341,6 @@ impl TypeUse<Unresolved> {
             TypeUse::NamedInline { index, .. } => Some(index),
             TypeUse::AnonymousInline(_) => None,
         }
-    }
-}
-
-impl<R: ResolvedState> TypeUse<R> {
-    pub fn single_result(valuetype: ValueType) -> Self {
-        Self::AnonymousInline(FunctionType {
-            results: vec![FResult { valuetype }],
-            params:  vec![],
-        })
     }
 }
 
@@ -644,8 +636,13 @@ pub enum Continuation {
 pub enum Operands<R: ResolvedState> {
     None,
     CallIndirect(Index<R, TableIndex>, TypeUse<R>),
-    Block(Option<Id>, TypeUse<R>, UncompiledExpr<R>, Continuation),
-    If(Option<Id>, TypeUse<R>, UncompiledExpr<R>, UncompiledExpr<R>),
+    Block(Option<Id>, BlockType<R>, UncompiledExpr<R>, Continuation),
+    If(
+        Option<Id>,
+        BlockType<R>,
+        UncompiledExpr<R>,
+        UncompiledExpr<R>,
+    ),
     BrTable(Vec<Index<R, LabelIndex>>, Index<R, LabelIndex>),
     SelectT(Vec<FResult>),
     FuncIndex(Index<R, FuncIndex>),

--- a/wrausmt-runtime/src/syntax/types.rs
+++ b/wrausmt-runtime/src/syntax/types.rs
@@ -59,7 +59,6 @@ pub enum RefType {
 pub enum ValueType {
     Num(NumType),
     Ref(RefType),
-    Void,
 }
 
 /// Result types classify the result of executing instructions or functions,


### PR DESCRIPTION
There are a few "special" blocktypes, the void type and the single value
result types. These don't correspond to an indexed type, instead the emitter
and runtime just handles them directly.

This also changes to emitting the function arity rather than the index, since
that's what's needed at runtime, and it makes it easier to handle these
special non-index types.

Also remove the "void" value, which doesn't really exist in WASM, and was just
a bad workaround for trying to populate an error parameter.
